### PR TITLE
Lokalise after iaps crowdin

### DIFF
--- a/DanaKit.xcodeproj/project.pbxproj
+++ b/DanaKit.xcodeproj/project.pbxproj
@@ -725,6 +725,9 @@
 				hi,
 				sk,
 				pt_BR,
+				ce,
+				hu,
+				uk,
 			);
 			mainGroup = 84752E7826ED0FFE009FD801;
 			packageReferences = (

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -203,8 +203,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+            "state" : "translated",
+            "value" : ". Ga naar de bluetooth instellingen, vergeet dit apparaat en probeer het opnieuw"
           }
         },
         "pl" : {
@@ -233,8 +233,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+            "state" : "translated",
+            "value" : ". Prejdi do nastavení bluetooth, odstráň toto zariadenie a skús to znova"
           }
         },
         "sv" : {
@@ -257,8 +257,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+            "state" : "translated",
+            "value" : ". Vui lòng vào cài đặt Bluetooth, quên thiết bị này rồi thử lại"
           }
         },
         "yy-YY" : {
@@ -345,7 +345,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
@@ -375,7 +375,7 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
@@ -399,7 +399,7 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
@@ -761,7 +761,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
@@ -791,7 +791,7 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
@@ -815,7 +815,7 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
@@ -898,7 +898,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
@@ -928,8 +928,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "12 sec/E"
+            "state" : "translated",
+            "value" : "12 sek/U"
           }
         },
         "sv" : {
@@ -952,7 +952,7 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
@@ -1590,7 +1590,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
@@ -1620,8 +1620,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "30 sec/E"
+            "state" : "translated",
+            "value" : "30 sek/U"
           }
         },
         "sv" : {
@@ -1644,7 +1644,7 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
@@ -1871,7 +1871,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
@@ -1901,8 +1901,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "60 sec/E"
+            "state" : "translated",
+            "value" : "60 sek/U"
           }
         },
         "sv" : {
@@ -1925,7 +1925,7 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
@@ -2979,8 +2979,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to bolus 5E?"
+            "state" : "translated",
+            "value" : "Weet je zeker dat je 5E wilt bolussen?"
           }
         },
         "pl" : {
@@ -3009,8 +3009,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to bolus 5E?"
+            "state" : "translated",
+            "value" : "Si si istý, že chceš podať bolus 5U?"
           }
         },
         "sv" : {
@@ -3033,8 +3033,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to bolus 5E?"
+            "state" : "translated",
+            "value" : "Bạn có chắc chắn muốn bolus 5E không?"
           }
         },
         "yy-YY" : {
@@ -3115,8 +3115,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+            "state" : "translated",
+            "value" : "Weet je zeker dat je het tijdelijk basaal wilt instellen op 200% gedurende 1 uur?"
           }
         },
         "pl" : {
@@ -3145,8 +3145,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+            "state" : "translated",
+            "value" : "Si si istý, že chceš nastaviť dočasný bazál na 200 % na 1 hodinu?"
           }
         },
         "sv" : {
@@ -3169,8 +3169,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+            "state" : "translated",
+            "value" : "Bạn có chắc chắn muốn đặt basal tạm thời 200% trong 1 giờ không?"
           }
         },
         "yy-YY" : {
@@ -4211,8 +4211,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery is empty. Replace it now!"
+            "state" : "translated",
+            "value" : "Batterij is leeg. Vervang hem nu!"
           }
         },
         "pl" : {
@@ -4241,8 +4241,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery is empty. Replace it now!"
+            "state" : "translated",
+            "value" : "Batéria je vybitá. Vymeň ju teraz!"
           }
         },
         "sv" : {
@@ -4265,8 +4265,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery is empty. Replace it now!"
+            "state" : "translated",
+            "value" : "Pin đã hết. Hãy thay ngay!"
           }
         },
         "yy-YY" : {
@@ -7922,8 +7922,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "DEBUG: Bolus action"
+            "state" : "translated",
+            "value" : "DEBUG: Bolus actie"
           }
         },
         "pl" : {
@@ -7952,8 +7952,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "DEBUG: Bolus action"
+            "state" : "translated",
+            "value" : "DEBUG: Akcia bolusu"
           }
         },
         "sv" : {
@@ -7976,8 +7976,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "DEBUG: Bolus action"
+            "state" : "translated",
+            "value" : "GỠ LỖI: Thao tác bolus"
           }
         },
         "yy-YY" : {
@@ -8058,8 +8058,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "DEBUG: Temp basal action"
+            "state" : "translated",
+            "value" : "DEBUG: tijdelijke basaal actie"
           }
         },
         "pl" : {
@@ -8088,8 +8088,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "DEBUG: Temp basal action"
+            "state" : "translated",
+            "value" : "DEBUG: Akcia dočasného bazálu"
           }
         },
         "sv" : {
@@ -8112,8 +8112,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "DEBUG: Temp basal action"
+            "state" : "translated",
+            "value" : "GỠ LỖI: Thao tác basal tạm thời"
           }
         },
         "yy-YY" : {
@@ -8605,8 +8605,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Device found!"
+            "state" : "translated",
+            "value" : "Apparaat gevonden!"
           }
         },
         "pl" : {
@@ -8635,8 +8635,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Device found!"
+            "state" : "translated",
+            "value" : "Zariadenie nájdené!"
           }
         },
         "sv" : {
@@ -8659,8 +8659,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Device found!"
+            "state" : "translated",
+            "value" : "Đã tìm thấy thiết bị!"
           }
         },
         "yy-YY" : {
@@ -9432,8 +9432,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Do bolus"
+            "state" : "translated",
+            "value" : "Bolus uitvoeren"
           }
         },
         "pl" : {
@@ -9462,8 +9462,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Do bolus"
+            "state" : "translated",
+            "value" : "Podaj bolus"
           }
         },
         "sv" : {
@@ -9486,8 +9486,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Do bolus"
+            "state" : "translated",
+            "value" : "Thực hiện bolus"
           }
         },
         "yy-YY" : {
@@ -10177,8 +10177,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+            "state" : "translated",
+            "value" : "Trong quá trình ghép đôi, DanaRS v1 của bạn sẽ hiển thị một thông báo ghép đôi, trong khi iPhone sẽ hiển thị thông báo nhập mã ghép đôi. Trên bơm, hãy chọn OK và nhập mã đó trên iPhone của bạn. Sau đó, Loop sẽ sẵn sàng giao tiếp với DanaRS v1"
           }
         },
         "yy-YY" : {
@@ -10261,8 +10261,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+            "state" : "translated",
+            "value" : "Tijdens het koppelingsproces toont je DanaRS v1 een koppelingsverzoek, terwijl je iPhone om een koppelingscode vraagt. Selecteer 'OK' op je pomp en voer de code in op je iPhone. Daarna is %1$@ klaar om te communiceren met je DanaRS v1"
           }
         },
         "pl" : {
@@ -10315,8 +10315,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+            "state" : "translated",
+            "value" : "Trong quá trình ghép đôi, DanaRS v3 của bạn sẽ hiển thị một thông báo ghép đôi, trong khi iPhone sẽ hiển thị thông báo nhập mã ghép đôi. Trên bơm, hãy chọn OK và nhập mã đó trên iPhone của bạn. Sau đó, Loop sẽ sẵn sàng giao tiếp với DanaRS v1"
           }
         },
         "yy-YY" : {
@@ -10596,8 +10596,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3"
+            "state" : "translated",
+            "value" : "Trong quá trình ghép đôi, DanaRS v3 của bạn sẽ hiển thị một thông báo ghép đôi, trong khi iPhone sẽ hiển thị thông báo nhập hai mã ghép đôi. Trên bơm, hãy chọn OK và nhập hai mã đó trên iPhone của bạn. Sau đó, Loop sẽ sẵn sàng giao tiếp với DanaRS v3"
           }
         },
         "yy-YY" : {
@@ -10952,8 +10952,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Error while starting scanning for devices..."
+            "state" : "translated",
+            "value" : "Fout bij het scannen naar apparaten..."
           }
         },
         "pl" : {
@@ -11006,8 +11006,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Error while starting scanning for devices..."
+            "state" : "translated",
+            "value" : "Lỗi khi bắt đầu quét thiết bị..."
           }
         },
         "yy-YY" : {
@@ -12062,8 +12062,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to pair to "
+            "state" : "translated",
+            "value" : "Kan niet koppelen aan "
           }
         },
         "pl" : {
@@ -12116,8 +12116,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to pair to "
+            "state" : "translated",
+            "value" : "Ghép đôi thất bại với "
           }
         },
         "yy-YY" : {
@@ -13349,8 +13349,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin\nSuspended"
+            "state" : "translated",
+            "value" : "Insulin\n Đã tạm ngưng"
           }
         },
         "yy-YY" : {
@@ -16596,7 +16596,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
@@ -16650,7 +16650,7 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
@@ -17713,8 +17713,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Prime amount"
+            "state" : "translated",
+            "value" : "Prime hoeveelheid"
           }
         },
         "pl" : {
@@ -17743,8 +17743,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Prime amount"
+            "state" : "translated",
+            "value" : "Množstvo naplnenia"
           }
         },
         "sv" : {
@@ -17767,8 +17767,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Prime amount"
+            "state" : "translated",
+            "value" : "Lượng insulin mồi"
           }
         },
         "yy-YY" : {
@@ -18542,8 +18542,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump is disconnected"
+            "state" : "translated",
+            "value" : "Pomp is ontkoppeld"
           }
         },
         "pl" : {
@@ -18572,8 +18572,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump is disconnected"
+            "state" : "translated",
+            "value" : "Pumpa je odpojená"
           }
         },
         "sv" : {
@@ -18596,8 +18596,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump is disconnected"
+            "state" : "translated",
+            "value" : "Bơm đã ngắt kết nối"
           }
         },
         "yy-YY" : {
@@ -19645,8 +19645,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconnect to pump"
+            "state" : "translated",
+            "value" : "Opnieuw verbinden met pomp"
           }
         },
         "pl" : {
@@ -19675,8 +19675,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconnect to pump"
+            "state" : "translated",
+            "value" : "Znovu pripojiť pumpu"
           }
         },
         "sv" : {
@@ -19699,8 +19699,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconnect to pump"
+            "state" : "translated",
+            "value" : "Kết nối lại máy bơm"
           }
         },
         "yy-YY" : {
@@ -21569,7 +21569,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
@@ -21599,8 +21599,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Scan"
+            "state" : "translated",
+            "value" : "Skenovať"
           }
         },
         "sv" : {
@@ -21623,8 +21623,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Scan"
+            "state" : "translated",
+            "value" : "Quét"
           }
         },
         "yy-YY" : {
@@ -25021,7 +25021,7 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
           }
         },
@@ -25051,8 +25051,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Stop bolus"
+            "state" : "translated",
+            "value" : "Zastaviť bolus"
           }
         },
         "sv" : {
@@ -25075,8 +25075,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Stop bolus"
+            "state" : "translated",
+            "value" : "Dừng bolus"
           }
         },
         "yy-YY" : {
@@ -25705,8 +25705,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "temp basal"
+            "state" : "translated",
+            "value" : "tijdelijke basaal"
           }
         },
         "pl" : {
@@ -25735,8 +25735,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "temp basal"
+            "state" : "translated",
+            "value" : "dočasný bazál"
           }
         },
         "sv" : {
@@ -25759,8 +25759,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "temp basal"
+            "state" : "translated",
+            "value" : "basal tạm thời"
           }
         },
         "yy-YY" : {
@@ -26801,8 +26801,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+            "state" : "translated",
+            "value" : "De pomp herinnert je wanneer de hoeveelheid insuline in de pomp dit niveau bereikt"
           }
         },
         "pl" : {
@@ -26831,8 +26831,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+            "state" : "translated",
+            "value" : "Pumpa ťa upozorní, keď množstvo inzulínu v pumpe dosiahne túto úroveň"
           }
         },
         "sv" : {
@@ -26855,8 +26855,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+            "state" : "translated",
+            "value" : "Bơm sẽ nhắc bạn khi lượng insulin trong bơm đạt đến mức này"
           }
         },
         "yy-YY" : {
@@ -28993,8 +28993,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "WARNING: Please don't use this until you've read the documentation"
+            "state" : "translated",
+            "value" : "WAARSCHUWING: Gebruik dit niet totdat je de documentatie hebt gelezen"
           }
         },
         "pl" : {
@@ -29023,8 +29023,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "WARNING: Please don't use this until you've read the documentation"
+            "state" : "translated",
+            "value" : "UPOZORNENIE: Nepoužívaj to, kým si neprečítaš dokumentáciu"
           }
         },
         "sv" : {
@@ -29047,8 +29047,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "WARNING: Please don't use this until you've read the documentation"
+            "state" : "translated",
+            "value" : "CẢNH BÁO: Vui lòng không sử dụng tính năng này cho đến khi bạn đã đọc tài liệu hướng dẫn"
           }
         },
         "yy-YY" : {
@@ -31458,8 +31458,8 @@
         },
         "nl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your pump is disconnected longer than 5 minutes!"
+            "state" : "translated",
+            "value" : "Je pomp is langer dan 5 minuten niet meer verbonden!"
           }
         },
         "pl" : {
@@ -31488,8 +31488,8 @@
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your pump is disconnected longer than 5 minutes!"
+            "state" : "translated",
+            "value" : "Tvoja pumpa je odpojená dlhšie ako 5 minút!"
           }
         },
         "sv" : {
@@ -31512,8 +31512,8 @@
         },
         "vi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your pump is disconnected longer than 5 minutes!"
+            "state" : "translated",
+            "value" : "Bơm của bạn đã bị ngắt kết nối hơn 5 phút!"
           }
         },
         "yy-YY" : {

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -10,12 +10,6 @@
             "value" : " جاهز للاستخدام!"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : " je připraven k použití!"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -48,7 +42,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : " is ready to be used!"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : " is ready to be used!"
           }
         },
@@ -58,16 +58,10 @@
             "value" : " è pronto per essere utilizzato!"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : " が使えるようになった！"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "er klar til bruk!"
+            "state" : "new",
+            "value" : " is ready to be used!"
           }
         },
         "nl" : {
@@ -82,16 +76,16 @@
             "value" : " jest gotowy do użycia!"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : " está pronto para ser usado!"
+            "state" : "new",
+            "value" : " is ready to be used!"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : " este gata să fie utilizat!"
+            "state" : "new",
+            "value" : " is ready to be used!"
           }
         },
         "ru" : {
@@ -103,7 +97,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : " je pripravený na použitie!"
+            "value" : " je pripravená na používanie!"
           }
         },
         "sv" : {
@@ -118,9 +112,21 @@
             "value" : " kullanılmaya hazır!"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "готовий до використання!"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : " đã sẵn sàng để sử dụng!"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : " is ready to be used!"
           }
         },
@@ -135,10 +141,130 @@
     ". Please go to your bluetooth settings, forget this device, and try again" : {
       "comment" : "Dana-i failed to pair p2",
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gå til Bluetooth-innstillingene, glem denne enheten og prøv på nytt."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ". Gå till inställningarna för Bluetooth och glöm den här enheten och försök sedan igen"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
         "zh-Hans" : {
@@ -151,15 +277,141 @@
     },
     "%@%@ / %@%@" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
-        "nb" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         }
@@ -168,10 +420,136 @@
     "%@U" : {
       "comment" : "Format string for reservoir volume. (1: The localized volume)",
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
+        "da" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%@E"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@U"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@U"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ U"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@U"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@U"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@E"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@E"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@J"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@Ед"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@ j"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@E"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@Ü"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@U"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@U"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@U"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%@U"
           }
         }
       }
@@ -179,25 +557,277 @@
     "%1$@ units remaining at %2$@" : {
       "comment" : "Accessibility format string for (1: localized volume)(2: time)",
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ enheder tilbage på %2$@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ IE verbleibend bei %2$@"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "quedan %1$@ unidades a las %2$@"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ yksikköä jäljellä klo %2$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ unités restantes à %2$@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ unità rimanenti alle ore %2$@"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ enheter gjenstår ved %2$@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ eenheden over om %2$@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ jednostek pozostaje w %2$@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ unidades restantes em %2$@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ ед остается в %2$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ jednotiek zostávajúcich na %2$@"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ enheter återstår kl. %2$@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ ünite kaldı %2$@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ одиниць залишилося на %2$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ units vẫn đang còn lúc %2$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$@ units remaining at %2$@"
           }
         }
       }
     },
     "%u %@" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
         "en" : {
           "stringUnit" : {
             "state" : "new",
             "value" : "%1$u %2$@"
           }
         },
-        "nb" : {
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "%1$u %2$@"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "%1$u %2$@"
           }
         }
@@ -206,10 +836,136 @@
     "12 sec/E" : {
       "comment" : "Dana bolus speed 12u per min",
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "12 sek/E"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 sek/E"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "12 sec/E"
           }
         }
       }
@@ -224,12 +980,6 @@
             "value" : "12 ثانية/و"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "12 sec/U"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -239,7 +989,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "12 sec/U"
+            "value" : "12 Sek/U"
           }
         },
         "en" : {
@@ -262,13 +1012,19 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "12 sec/U"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "12 sec/U"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "12 sec/U"
           }
         },
@@ -278,22 +1034,16 @@
             "value" : "12 sec/U"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "12秒/U"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "12 sek/u"
+            "state" : "new",
+            "value" : "12 sec/U"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "12 sec/U"
+            "value" : "12 sec/E"
           }
         },
         "pl" : {
@@ -302,28 +1052,28 @@
             "value" : "12 sek/U"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "12 seg/U"
+            "state" : "new",
+            "value" : "12 sec/U"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "12 sec/U"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "12 сек/U"
+            "value" : "12 сек/ед"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "12 sekúnd/U"
+            "value" : "12 sek/U"
           }
         },
         "sv" : {
@@ -338,9 +1088,21 @@
             "value" : "12 saniye/U"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 секунд/U"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "12 sec/U"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "12 sec/U"
           }
         },
@@ -359,12 +1121,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ترميز 12 ساعة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zápis 12h"
           }
         },
         "da" : {
@@ -399,7 +1155,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "12h notation"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "12h notation"
           }
         },
@@ -409,16 +1171,10 @@
             "value" : "Notazione 12h"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "12h表記"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "12 timers notasjon"
+            "state" : "new",
+            "value" : "12h notation"
           }
         },
         "nl" : {
@@ -433,34 +1189,34 @@
             "value" : "Notacja 12h"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notação de 12h"
+            "state" : "new",
+            "value" : "12h notation"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notație 12h"
+            "state" : "new",
+            "value" : "12h notation"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "12-часовая нотация"
+            "value" : "12ч формат"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zápis 12h"
+            "value" : "12h režim"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "12h notation"
+            "value" : "12-timmarsvisning"
           }
         },
         "tr" : {
@@ -469,9 +1225,21 @@
             "value" : "12h notasyonu"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12-годинна нотація"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Ký hiệu 12h"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "12h notation"
           }
         },
@@ -492,16 +1260,10 @@
             "value" : "عرض 24 ساعة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "24hodinový displej"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "24 timers visning"
+            "value" : "24-timers visning"
           }
         },
         "de" : {
@@ -530,7 +1292,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "24h display"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "24h display"
           }
         },
@@ -540,16 +1308,10 @@
             "value" : "Display 24 ore su 24"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "24時間表示"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "24 timers visning"
+            "state" : "new",
+            "value" : "24h display"
           }
         },
         "nl" : {
@@ -564,16 +1326,16 @@
             "value" : "Wyświetlacz 24h"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Exibição de 24 horas"
+            "state" : "new",
+            "value" : "24h display"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Afișaj 24h"
+            "state" : "new",
+            "value" : "24h display"
           }
         },
         "ru" : {
@@ -585,7 +1347,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "24-hodinový displej"
+            "value" : "Formát hodín"
           }
         },
         "sv" : {
@@ -600,9 +1362,21 @@
             "value" : "24 saat gösterge"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "24-годинний дисплей"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "24h display"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "24h display"
           }
         },
@@ -623,16 +1397,10 @@
             "value" : "ترميز 24 ساعة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "24hodinový zápis"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "24 timers notation"
+            "value" : "24-timers notation"
           }
         },
         "de" : {
@@ -661,7 +1429,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "24h notation"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "24h notation"
           }
         },
@@ -671,16 +1445,10 @@
             "value" : "Notazione 24h"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "24時間表記"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "24-timers notasjon"
+            "state" : "new",
+            "value" : "24h notation"
           }
         },
         "nl" : {
@@ -695,34 +1463,34 @@
             "value" : "Notacja 24h"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notação de 24 horas"
+            "state" : "new",
+            "value" : "24h notation"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notație 24h"
+            "state" : "new",
+            "value" : "24h notation"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "24-часовая нотация"
+            "value" : "24ч формат"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "24-hodinový zápis"
+            "value" : "24h režim"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "24h notation"
+            "value" : "24-timmarsvisning"
           }
         },
         "tr" : {
@@ -731,9 +1499,21 @@
             "value" : "24 saat gösterimi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12-годинна нотація"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Ký hiệu 24h"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "24h notation"
           }
         },
@@ -748,10 +1528,136 @@
     "30 sec/E" : {
       "comment" : "Dana bolus speed 30u per min",
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "30 sek/E"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 sek/E"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "30 sec/E"
           }
         }
       }
@@ -766,12 +1672,6 @@
             "value" : "30 ثانية/و"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 sec/U"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -781,7 +1681,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "30 sec/U"
+            "value" : "30 Sek/U"
           }
         },
         "en" : {
@@ -804,13 +1704,19 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "30 sec/U"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "30 sec/U"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "30 sec/U"
           }
         },
@@ -820,22 +1726,16 @@
             "value" : "30 sec/U"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "30秒/U"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 sek/u"
+            "state" : "new",
+            "value" : "30 sec/U"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "30 sec/U"
+            "value" : "30 sec/E"
           }
         },
         "pl" : {
@@ -844,28 +1744,28 @@
             "value" : "30 s/U"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "30 seg/U"
+            "state" : "new",
+            "value" : "30 sec/U"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "30 sec/U"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "30 сек/U"
+            "value" : "30 сек/ед"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "30 sekúnd/U"
+            "value" : "30 sek/U"
           }
         },
         "sv" : {
@@ -880,9 +1780,21 @@
             "value" : "30 saniye/U"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 секунд/U"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "30 sec/U"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "30 sec/U"
           }
         },
@@ -897,10 +1809,136 @@
     "60 sec/E" : {
       "comment" : "Dana bolus speed 60u per min",
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "60 sek/E"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "60 sek/E"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "60 sec/E"
           }
         }
       }
@@ -915,12 +1953,6 @@
             "value" : "60 ثانية/و"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "60 sec/U"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -930,7 +1962,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "60 sec/U"
+            "value" : "60 Sek/U"
           }
         },
         "en" : {
@@ -953,13 +1985,19 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "60 sec/U"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "60 sec/U"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "60 sec/U"
           }
         },
@@ -969,22 +2007,16 @@
             "value" : "60 sec/U"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "60秒/U"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "60 sek/E"
+            "state" : "new",
+            "value" : "60 sec/U"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "60 sec/U"
+            "value" : "60 sec/E"
           }
         },
         "pl" : {
@@ -993,28 +2025,28 @@
             "value" : "60 s/U"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "60 seg/U"
+            "state" : "new",
+            "value" : "60 sec/U"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "60 sec/U"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "60 сек/U"
+            "value" : "60 сек/ед"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "60 sekúnd/U"
+            "value" : "60 sek/U"
           }
         },
         "sv" : {
@@ -1029,9 +2061,21 @@
             "value" : "60 saniye/U"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "60 секунд/U"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "60 sec/U"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "60 sec/U"
           }
         },
@@ -1052,16 +2096,10 @@
             "value" : "لقد تم إعداد تذكير بفحص مستوى الجلوكوز في الدم في المضخة وتم تشغيله. يُرجى إزالته أو إعطاء مستوى الجلوكوز للمضخة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "V pumpě byla nastavena připomínka kontroly glykemie, která se spustí. Prosím, odstraňte ji nebo zadejte hladinu glukózy do pumpy."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Der er installeret en påmindelse om blodsukkerkontrol i din pumpe, og den udløses. Fjern den, eller giv dit blodsukkerniveau til pumpen."
+            "value" : "En påmindelse om blodsukkerkontrol i er blevet opsat i pumpen og er udløst. Fjern den, eller informér pumpen om dit blodsukkerniveau"
           }
         },
         "de" : {
@@ -1090,7 +2128,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "A blood glucose check reminder has been setup in your pump and is triggered. Please remove it or give your glucose level to the pump"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "A blood glucose check reminder has been setup in your pump and is triggered. Please remove it or give your glucose level to the pump"
           }
         },
@@ -1100,16 +2144,10 @@
             "value" : "Nel microinfusore è stato impostato un promemoria per il controllo della glicemia, che è stato attivato. Si prega di rimuoverlo o di fornire il livello di glucosio al microinfusore."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "血糖値チェックリマインダーがポンプに設定され、作動しています。リマインダーを外すか、血糖値をポンプに知らせてください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "En påminnelse om blodsukkerkontroll er satt opp i pumpen og utløses. Fjern den eller gi glukosenivået til pumpen"
+            "state" : "new",
+            "value" : "A blood glucose check reminder has been setup in your pump and is triggered. Please remove it or give your glucose level to the pump"
           }
         },
         "nl" : {
@@ -1124,16 +2162,16 @@
             "value" : "Przypomnienie o sprawdzeniu poziomu glukozy we krwi zostało skonfigurowane w pompie i jest uruchamiane. Należy je usunąć lub podać poziom glukozy do pompy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Um lembrete de verificação de glicose no sangue foi configurado em sua bomba e está acionado. Remova-o ou forneça seu nível de glicose para a bomba"
+            "state" : "new",
+            "value" : "A blood glucose check reminder has been setup in your pump and is triggered. Please remove it or give your glucose level to the pump"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Un memento de verificare a glicemiei a fost configurat în pompa dvs. și este activat. Vă rugăm să îl eliminați sau să comunicați nivelul de glucoză pompei"
+            "state" : "new",
+            "value" : "A blood glucose check reminder has been setup in your pump and is triggered. Please remove it or give your glucose level to the pump"
           }
         },
         "ru" : {
@@ -1160,9 +2198,21 @@
             "value" : "Pompanızda bir kan şekeri kontrolü hatırlatıcısı ayarlanmıştır ve tetiklenmiştir. Lütfen bunu kaldırın veya glikoz seviyenizi pompaya verin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нагадування про перевірку рівня глюкози в крові було налаштовано у вашій Помпі та спрацьовує. Будь ласка, видаліть його або дайте свій рівень глюкози на помпі"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Lời nhắc kiểm tra lượng đường trong máu đã được thiết lập trong máy bơm của bạn và được kích hoạt. Vui lòng tháo nó ra hoặc đưa mức đường huyết của bạn vào máy bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "A blood glucose check reminder has been setup in your pump and is triggered. Please remove it or give your glucose level to the pump"
           }
         },
@@ -1181,12 +2231,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "مهلة البلعة نشطة. لا يمكن إكمال دورة الحلقة حتى تصبح المهلة غير نشطة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Časový limit bolusu je aktivní. Cyklus smyčky nelze dokončit, dokud není časový limit neaktivní."
           }
         },
         "da" : {
@@ -1221,7 +2265,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive"
           }
         },
@@ -1231,16 +2281,10 @@
             "value" : "È attivo un timeout del bolo. Il ciclo del bolo non può essere completato finché il timeout non è attivo."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーラスタイムアウトが有効である。ループサイクルはタイムアウトが解除されるまで完了しない。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus-timeout er aktiv. Sløyfen kan ikke fullføres før timeouten er over."
+            "state" : "new",
+            "value" : "A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive"
           }
         },
         "nl" : {
@@ -1255,22 +2299,22 @@
             "value" : "Limit czasu bolusa jest aktywny. Cykl pętli nie może zostać zakończony, dopóki limit czasu jest nieaktywny"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Um tempo limite de bolus está ativo. O ciclo de loop não pode ser concluído até que o tempo limite esteja inativo"
+            "state" : "new",
+            "value" : "A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Un timp de așteptare pentru bolus este activ. Ciclul de buclă nu poate fi finalizat până când timpul de așteptare nu este inactiv"
+            "state" : "new",
+            "value" : "A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Тайм-аут болюса активен. Цикл цикла не может быть завершен до тех пор, пока таймаут не станет неактивным"
+            "value" : "Тайм-аут болюса активен. Цикл петли не может быть завершен пока тайм-аут активен"
           }
         },
         "sk" : {
@@ -1291,9 +2335,21 @@
             "value" : "Bir bolus zaman aşımı etkindir. Zaman aşımı devre dışı kalana kadar döngü döngüsü tamamlanamaz"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тайм-аут болюсу активний. Цикл loop не може бути завершений, доки тайм-аут не буде неактивним"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Thời gian chờ bolus đang hoạt động. Chu kỳ vòng lặp không thể hoàn tất cho đến khi thời gian chờ không hoạt động"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive"
           }
         },
@@ -1314,16 +2370,10 @@
             "value" : "تم إلغاء الإجراء، لأن المضخة مشغولة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Akce byla zrušena, protože čerpadlo je obsazeno."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Handlingen er blevet aflyst, fordi pumpen er optaget"
+            "value" : "Handlingen er blevet afbrudt, da pumpen er optaget"
           }
         },
         "de" : {
@@ -1352,7 +2402,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Action has been canceled, because the pump is busy"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Action has been canceled, because the pump is busy"
           }
         },
@@ -1362,16 +2418,10 @@
             "value" : "L'azione è stata annullata perché la pompa è occupata."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプがビジー状態のため、アクションはキャンセルされました。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Handlingen er avbrutt fordi pumpen er opptatt"
+            "state" : "new",
+            "value" : "Action has been canceled, because the pump is busy"
           }
         },
         "nl" : {
@@ -1386,28 +2436,28 @@
             "value" : "Działanie zostało anulowane, ponieważ pompa jest zajęta"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "A ação foi cancelada porque a bomba está ocupada"
+            "state" : "new",
+            "value" : "Action has been canceled, because the pump is busy"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acțiunea a fost anulată, deoarece pompa este ocupată"
+            "state" : "new",
+            "value" : "Action has been canceled, because the pump is busy"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Действие было отменено, так как насос занят"
+            "value" : "Действие было отменено, так как помпа занята"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Akcia bola zrušená, pretože čerpadlo je obsadené"
+            "value" : "Akcia bola zrušená, pretože pumpa je zaneprázdnená"
           }
         },
         "sv" : {
@@ -1422,9 +2472,21 @@
             "value" : "Pompa meşgul olduğu için işlem iptal edildi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Дія скасована, оскільки Помпа зайнята"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Hành động đã bị hủy, vì máy bơm đang bận"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Action has been canceled, because the pump is busy"
           }
         },
@@ -1445,16 +2507,10 @@
             "value" : "بعد إعداد نوع الأنسولين وسرعة البلعة، ستظهر لك شاشة تحتوي على جميع مضخات دانا الموجودة. حدد المضخة التي تريد ربطها مع %1$@."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Po nastavení typu inzulínu a rychlosti bolusu se zobrazí obrazovka se všemi nalezenými pumpami Dana. Vyberte pumpu, kterou chcete propojit se stránkou %1$@."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Når du har indstillet insulintype og bolushastighed, får du vist en skærm med alle fundne Dana-pumper. Vælg den pumpe, du vil forbinde med %1$@."
+            "value" : "Efter opsætning af insulintype og bolushastighed, får man vist en skærm med alle fundne Dana-pumper. Vælg den pumpe, der skal forbindes med %1$@."
           }
         },
         "de" : {
@@ -1489,7 +2545,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "After setting up the insulin type and bolus speed, you will see a screen with all found Dana pumps. Select the pump you want to link with %1$@."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "After setting up the insulin type and bolus speed, you will see a screen with all found Dana pumps. Select the pump you want to link with %1$@."
           }
         },
@@ -1499,16 +2561,10 @@
             "value" : "Dopo aver impostato il tipo di insulina e la velocità del bolo, verrà visualizzata una schermata con tutti i microinfusori Dana trovati. Selezionare il microinfusore che si desidera collegare a %1$@."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "インスリンの種類とボーラス速度を設定した後、見つかったすべての Dana ポンプの画面が表示されます。 %1$@とリンクさせたいポンプを選択してください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etter at du har konfigurert insulintype og bolushastighet, vil du se en skjerm med alle funnet Dana-pumper. Velg pumpen du vil koble til %1$@."
+            "state" : "new",
+            "value" : "After setting up the insulin type and bolus speed, you will see a screen with all found Dana pumps. Select the pump you want to link with %1$@."
           }
         },
         "nl" : {
@@ -1523,22 +2579,22 @@
             "value" : "Po ustawieniu typu insuliny i szybkości bolusa pojawi się ekran ze wszystkimi znalezionymi pompami Dana. Wybierz pompę, którą chcesz połączyć z %1$@."
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Depois de configurar o tipo de insulina e a velocidade do bolus, você verá uma tela com todas as bombas Dana encontradas. Selecione a bomba que você deseja vincular ao site %1$@."
+            "state" : "new",
+            "value" : "After setting up the insulin type and bolus speed, you will see a screen with all found Dana pumps. Select the pump you want to link with %1$@."
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "După setarea tipului de insulină și a vitezei bolusului, veți vedea un ecran cu toate pompele Dana găsite. Selectați pompa pe care doriți să o legați cu %1$@."
+            "state" : "new",
+            "value" : "After setting up the insulin type and bolus speed, you will see a screen with all found Dana pumps. Select the pump you want to link with %1$@."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "После настройки типа инсулина и скорости болюса вы увидите экран со всеми найденными помпами Dana. Выберите помпу, которую вы хотите связать с %1$@."
+            "value" : "После настройки типа инсулина и скорости болюса вы увидите экран со всеми найденными помпами Dana. Выберите помпу, которую Вы хотите связать с %1$@."
           }
         },
         "sk" : {
@@ -1559,9 +2615,21 @@
             "value" : "İnsülin tipini ve bolus hızını ayarladıktan sonra, bulunan tüm Dana pompalarını içeren bir ekran göreceksiniz. %1$@ile bağlamak istediğiniz pompayı seçin."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Після налаштування типу інсуліну та швидкості болюса ви побачите екран із усіма знайденими помпами Dana. Виберіть помпу, яку потрібно зв'язати з %1$@."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Sau khi thiết lập loại insulin và tốc độ bolus, bạn sẽ thấy màn hình với tất cả các máy bơm Dana được tìm thấy. Chọn máy bơm bạn muốn liên kết với %1$@."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "After setting up the insulin type and bolus speed, you will see a screen with all found Dana pumps. Select the pump you want to link with %1$@."
           }
         },
@@ -1582,16 +2650,10 @@
             "value" : "صفير المنبه"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pípání budíku"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alarmen bipper"
+            "value" : "Alarmbip"
           }
         },
         "de" : {
@@ -1620,7 +2682,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Alarm beeps"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Alarm beeps"
           }
         },
@@ -1630,16 +2698,10 @@
             "value" : "Segnale acustico dell'allarme"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "アラームビープ音"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alarmen piper"
+            "state" : "new",
+            "value" : "Alarm beeps"
           }
         },
         "nl" : {
@@ -1654,28 +2716,28 @@
             "value" : "Sygnały dźwiękowe alarmu"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "O alarme emite um bipe"
+            "state" : "new",
+            "value" : "Alarm beeps"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alarma emite un semnal sonor"
+            "state" : "new",
+            "value" : "Alarm beeps"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Звуковые сигналы тревоги"
+            "value" : "Сигналы тревоги"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pípanie budíka"
+            "value" : "Upozornenia"
           }
         },
         "sv" : {
@@ -1690,9 +2752,21 @@
             "value" : "Alarm bip sesi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Звукові сигнали"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Báo động tiếp beeps"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Alarm beeps"
           }
         },
@@ -1713,16 +2787,10 @@
             "value" : "حدث خطأ غير معروف أثناء معالجة التنبيه من المضخة. يرجى الإبلاغ عن ذلك"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Při zpracování výstrahy z čerpadla došlo k neznámé chybě. Nahlaste to prosím"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Der er opstået en ukendt fejl under behandlingen af alarmen fra pumpen. Rapporter venligst dette"
+            "value" : "En ukendt fejl er opstået under behandlingen af alarmen fra pumpen. Anmeld venligst dette"
           }
         },
         "de" : {
@@ -1751,7 +2819,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "An unknown error has occurred during processing the alert from the pump. Please report this"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "An unknown error has occurred during processing the alert from the pump. Please report this"
           }
         },
@@ -1761,16 +2835,10 @@
             "value" : "Si è verificato un errore sconosciuto durante l'elaborazione dell'avviso dal microinfusore. Si prega di segnalare questo"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプからのアラート処理中に不明なエラーが発生しました。このエラーを報告してください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Det har oppstått en ukjent feil under behandlingen av varselet fra pumpen. Vennligst rapporter dette"
+            "state" : "new",
+            "value" : "An unknown error has occurred during processing the alert from the pump. Please report this"
           }
         },
         "nl" : {
@@ -1785,22 +2853,22 @@
             "value" : "Podczas przetwarzania powiadomienia z pompy wystąpił nieznany błąd. Zgłoś ten błąd"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocorreu um erro desconhecido durante o processamento do alerta da bomba. Informe esse erro"
+            "state" : "new",
+            "value" : "An unknown error has occurred during processing the alert from the pump. Please report this"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "O eroare necunoscută a apărut în timpul procesării alertei de la pompă. Vă rugăm să raportați acest lucru"
+            "state" : "new",
+            "value" : "An unknown error has occurred during processing the alert from the pump. Please report this"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "При обработке оповещения от насоса произошла неизвестная ошибка. Пожалуйста, сообщите об этом"
+            "value" : "При обработке сигнала от помпы произошла неизвестная ошибка. Пожалуйста, сообщите об этом"
           }
         },
         "sk" : {
@@ -1821,9 +2889,21 @@
             "value" : "Pompadan gelen uyarının işlenmesi sırasında bilinmeyen bir hata oluştu. Lütfen bunu rapor edin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Під час обробки сповіщення від Помпи сталася невідома помилка. Будь ласка, повідомте про це"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã xảy ra lỗi không xác định trong quá trình xử lý cảnh báo từ máy bơm. Vui lòng báo cáo lỗi này"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "An unknown error has occurred during processing the alert from the pump. Please report this"
           }
         },
@@ -1837,10 +2917,130 @@
     },
     "Are you sure you want to bolus 5E?" : {
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Er du sikker på at du vil gi bolus 5E?"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Är du säker på att du vill ge 5E insulin?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to bolus 5E?"
           }
         },
         "zh-Hans" : {
@@ -1853,10 +3053,130 @@
     },
     "Are you sure you want to set the temp basal to 200% for 1 hour?" : {
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Er du sikker på at du vil sette temp basal til 200 % i 1 time?"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Är du säker på att du vill ställa in en temporär basal på 200% i 1 timme?"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
         "zh-Hans" : {
@@ -1876,16 +3196,10 @@
             "value" : "هل أنت متأكد من رغبتك في التوقف عن استخدام Dana-i/RS؟"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jste si jisti, že chcete přestat používat Dana-i/RS?"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Er du sikker på, at du vil stoppe med at bruge Dana-i/RS?"
+            "value" : "Sikker på, at brug af Dana-i/RS skal ophøre?"
           }
         },
         "de" : {
@@ -1914,7 +3228,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Are you sure you want to stop using Dana-i/RS?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Are you sure you want to stop using Dana-i/RS?"
           }
         },
@@ -1924,16 +3244,10 @@
             "value" : "Siete sicuri di voler smettere di usare Dana-i/RS?"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "本当にDana-i/RSをやめたいのですか？"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Er du sikker på at du vil slutte å bruke Dana-i/RS?"
+            "state" : "new",
+            "value" : "Are you sure you want to stop using Dana-i/RS?"
           }
         },
         "nl" : {
@@ -1948,16 +3262,16 @@
             "value" : "Czy na pewno chcesz przestać używać Dana-i/RS?"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tem certeza de que deseja parar de usar o Dana-i/RS?"
+            "state" : "new",
+            "value" : "Are you sure you want to stop using Dana-i/RS?"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sunteți sigur că doriți să nu mai folosiți Dana-i/RS?"
+            "state" : "new",
+            "value" : "Are you sure you want to stop using Dana-i/RS?"
           }
         },
         "ru" : {
@@ -1984,9 +3298,21 @@
             "value" : "Dana-i/RS kullanmayı bırakmak istediğinizden emin misiniz?"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ви впевнені, що хочете припинити використання Dana-i/RS?"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Bạn có chắc chắn muốn ngừng sử dụng Dana-i không?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Are you sure you want to stop using Dana-i/RS?"
           }
         },
@@ -2007,16 +3333,10 @@
             "value" : "إضاءة خلفية في الوقت المحدد"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Doba zapnutí podsvícení"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tændingstid for baggrundsbelysning"
+            "value" : "Baggrundslys på tidspunktet"
           }
         },
         "de" : {
@@ -2028,7 +3348,7 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tiempo de encendido de la retroiluminación"
+            "value" : "Tiempo de retroiluminación"
           }
         },
         "fi" : {
@@ -2040,31 +3360,31 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Durée d'allumage du rétroéclairage"
+            "value" : "La vérité sur l'âge"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Backlight on time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Backlight on time"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tempo di accensione della retroilluminazione"
+            "value" : "Verifica del periodo"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "世界へ"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bakgrunnsbelysning i tid"
+            "state" : "new",
+            "value" : "Backlight on time"
           }
         },
         "nl" : {
@@ -2079,22 +3399,22 @@
             "value" : "Czas włączenia podświetlenia"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tempo de ativação da luz de fundo"
+            "state" : "new",
+            "value" : "Backlight on time"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timp de aprindere a luminii de fundal"
+            "state" : "new",
+            "value" : "Backlight on time"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Время включения подсветки"
+            "value" : "Время подсветки экрана"
           }
         },
         "sk" : {
@@ -2112,19 +3432,31 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Arka ışık açık kalma süresi"
+            "value" : "Arka ışık açma süresi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Час увімкнення Підсвічування "
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đèn nền theo thời gian"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Backlight on time"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "背光开启时间"
+            "value" : "生活"
           }
         }
       }
@@ -2136,12 +3468,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "القاعدية"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazální"
           }
         },
         "da" : {
@@ -2158,7 +3484,7 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Basal"
           }
         },
@@ -2170,13 +3496,19 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Basal"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal"
           }
         },
@@ -2186,15 +3518,9 @@
             "value" : "Basale"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ベーサル"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Basal"
           }
         },
@@ -2210,22 +3536,22 @@
             "value" : "Podstawowy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Basal"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazal"
+            "state" : "new",
+            "value" : "Basal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Базальный"
+            "value" : "Базал"
           }
         },
         "sk" : {
@@ -2246,9 +3572,21 @@
             "value" : "Bazal"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Базал"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Basal"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal"
           }
         },
@@ -2267,12 +3605,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "مقارنة قاعدية"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Základní porovnání"
           }
         },
         "da" : {
@@ -2307,7 +3639,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Basal Compare"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal Compare"
           }
         },
@@ -2317,15 +3655,9 @@
             "value" : "Basale Confronta"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ベース比較"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Basal Compare"
           }
         },
@@ -2341,22 +3673,22 @@
             "value" : "Porównanie podstawowe"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comparação basal"
+            "state" : "new",
+            "value" : "Basal Compare"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comparație bazală"
+            "state" : "new",
+            "value" : "Basal Compare"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Базальное сравнение"
+            "value" : "Сравнение Базала"
           }
         },
         "sk" : {
@@ -2377,9 +3709,21 @@
             "value" : "Bazal Karşılaştırma"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Базальне порівняння"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Basal Compare"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal Compare"
           }
         },
@@ -2398,12 +3742,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "بلوغ الحد الأساسي"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dosažení základního limitu"
           }
         },
         "da" : {
@@ -2438,7 +3776,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Basal limit reached"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal limit reached"
           }
         },
@@ -2448,22 +3792,16 @@
             "value" : "Limite basale raggiunto"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "基礎限界に到達"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Basal limit reached"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basaal limiet bereikt"
+            "value" : "Basale limiet bereikt"
           }
         },
         "pl" : {
@@ -2472,22 +3810,22 @@
             "value" : "Osiągnięty limit podstawowy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite basal atingido"
+            "state" : "new",
+            "value" : "Basal limit reached"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limita bazală atinsă"
+            "state" : "new",
+            "value" : "Basal limit reached"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Базовый предел достигнут"
+            "value" : "Достигнут лимит Базала"
           }
         },
         "sk" : {
@@ -2508,9 +3846,21 @@
             "value" : "Bazal sınıra ulaşıldı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Базальний ліміт досягнуто"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã đạt đến giới hạn liều cơ bản"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal limit reached"
           }
         },
@@ -2528,13 +3878,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "المظهر الجانبي القاعدي"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Základní profil"
+            "value" : "ملف الانسولين القاعدي"
           }
         },
         "da" : {
@@ -2546,31 +3890,37 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Grundlegendes Profil"
+            "value" : "Basal-Profil"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Perfil basal"
+            "value" : "Perfil de basal"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Perusprofiili"
+            "value" : "Perusinsuliiniprofiili"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Profil de base"
+            "value" : "Profil Basal"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Basal profile"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bázis profil"
           }
         },
         "it" : {
@@ -2579,40 +3929,34 @@
             "value" : "Profilo basale"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "基本プロファイル"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basal profile"
+            "value" : "Basalprofil"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basaal profiel"
+            "value" : "Basaalprofiel"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Profil podstawowy"
+            "value" : "Profil bazy"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Perfil Basal"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Perfil basal"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Profil bazal"
+            "value" : "Perfil Basal"
           }
         },
         "ru" : {
@@ -2624,13 +3968,13 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Základný profil"
+            "value" : "Bazálny profil"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basal profil"
+            "value" : "Basalinställningar"
           }
         },
         "tr" : {
@@ -2639,16 +3983,28 @@
             "value" : "Bazal profil"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Базальний профіль"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Phác đồ liều nền"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Basal profile"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "基本概况"
+            "value" : "基础率配置文件"
           }
         }
       }
@@ -2665,49 +4021,55 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batteriets alder"
+            "value" : "Batterialder"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alter der Batterie"
+            "value" : "Batteriealter"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Edad de la batería"
+            "state" : "new",
+            "value" : "Battery age"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Akun ikä"
+            "state" : "new",
+            "value" : "Battery age"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Âge de la batterie"
+            "state" : "new",
+            "value" : "Battery age"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Battery age"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Battery age"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Età della batteria"
+            "value" : "Durata Batteria"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Batteri alder"
+            "state" : "new",
+            "value" : "Battery age"
           }
         },
         "nl" : {
@@ -2718,14 +4080,20 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wiek baterii"
+            "state" : "new",
+            "value" : "Battery age"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery age"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idade da bateria"
+            "state" : "new",
+            "value" : "Battery age"
           }
         },
         "ru" : {
@@ -2743,13 +4111,19 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batteriets ålder"
+            "value" : "Batteriålder"
           }
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery age"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Pil yaşı"
+            "value" : "Час використовування батареї"
           }
         },
         "vi" : {
@@ -2758,10 +4132,16 @@
             "value" : "Battery age"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery age"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "电池寿命"
+            "state" : "new",
+            "value" : "Battery age"
           }
         }
       }
@@ -2769,6 +4149,132 @@
     "Battery is empty. Replace it now!" : {
       "comment" : "Alert body for batteryZeroPercent",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpens batteri är tomt. Byt ut det nu!"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Battery is empty. Replace it now!"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2782,14 +4288,8 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "مستوى البطارية"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Úroveň nabití baterie"
+            "state" : "new",
+            "value" : "Battery level"
           }
         },
         "da" : {
@@ -2801,19 +4301,19 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batteriestand"
+            "value" : "Batteriefüllung"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nivel de batería"
+            "value" : "Nivel de bateria"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Akun varaustaso"
+            "state" : "new",
+            "value" : "Battery level"
           }
         },
         "fr" : {
@@ -2825,25 +4325,25 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "מצב הסוללה"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Battery level"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Livello della batteria"
+            "value" : "Livello Batteria"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "バッテリー残量"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Battery level"
+            "value" : "Batterinivå"
           }
         },
         "nl" : {
@@ -2858,28 +4358,28 @@
             "value" : "Poziom naładowania baterii"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nível da bateria"
+            "state" : "new",
+            "value" : "Battery level"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nivelul bateriei"
+            "state" : "new",
+            "value" : "Battery level"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Уровень заряда батареи"
+            "value" : "Уровень заряда"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Úroveň nabitia batérie"
+            "value" : "Stav batérie"
           }
         },
         "sv" : {
@@ -2894,16 +4394,28 @@
             "value" : "Pil seviyesi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Рівень заряду"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Mức pin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Battery level"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "电池电量"
+            "state" : "new",
+            "value" : "Battery level"
           }
         }
       }
@@ -2917,16 +4429,10 @@
             "value" : "قبل البدء بعملية الاقتران، يوصى بالتحقق من كلمة مرور المضخة وتحديثها إذا لزم الأمر. يمكنك القيام بذلك من خلال الانتقال إلى إعدادات المضخة -> إعدادات المستخدم -> كلمة المرور. كلمة المرور الافتراضية هي 1234، إذا كانت هذه هي كلمة المرور الخاصة بك، يُرجى التفكير في تغييرها"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Před zahájením procesu párování doporučujeme zkontrolovat a případně aktualizovat heslo čerpadla. To můžete provést v nastavení čerpadla -> nastavení uživatele -> heslo. Výchozí heslo je 1234, pokud je to vaše heslo, zvažte jeho změnu."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Før du går i gang med parringsprocessen, anbefales det at kontrollere og om nødvendigt opdatere pumpens adgangskode. Det kan du gøre ved at gå til pumpeindstillingerne -> brugerindstillinger -> adgangskode. Standardadgangskoden er 1234, og hvis det er din adgangskode, bør du overveje at ændre den."
+            "value" : "Før man går i gang med parringsprocessen, anbefales det at tjekke, og om nødvendigt opdatere, pumpens adgangskode. Det kan man gøre ved at gå til pumpeindstillinger -> brugerindstillinger -> adgangskode. Standardadgangskoden er 1234, og er det den adgangskode, man selv bruger, bør den skiftes"
           }
         },
         "de" : {
@@ -2955,7 +4461,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Before starting with the pairing process, it is recommended to check, and if needed update, the pump password. You can do this by going to the pump settings -> user settings -> password. The default password is 1234, if this is your password, please consider changing it"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Before starting with the pairing process, it is recommended to check, and if needed update, the pump password. You can do this by going to the pump settings -> user settings -> password. The default password is 1234, if this is your password, please consider changing it"
           }
         },
@@ -2965,22 +4477,16 @@
             "value" : "Prima di iniziare il processo di accoppiamento, si consiglia di controllare e, se necessario, aggiornare la password del microinfusore. È possibile farlo accedendo alle impostazioni del microinfusore -> impostazioni utente -> password. La password predefinita è 1234; se questa è la vostra password, prendete in considerazione la possibilità di cambiarla."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ペアリングを開始する前に、ポンプのパスワードを確認し、必要に応じて更新することをお勧めします。これはポンプ設定→ユーザー設定→パスワードで行うことができます。デフォルトのパスワードは1234です。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Before starting with the pairing process, it is recommended to check, and if needed update, the pump password. You can do this by going to the pump settings -> user settings -> password. The default password is 1234, if this is your password, please consider changing it"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Voordat je begint met het koppelproces, is het aan te raden om het wachtwoord van de pomp te controleren en zo nodig bij te werken. Je kunt dit doen via de pompinstellingen -> gebruikersinstellingen -> wachtwoord. Het standaard wachtwoord is 1234. Als dit je wachtwoord is, overweeg dan om het te wijzigen."
+            "value" : "Controleer vóór het koppelen het wachtwoord van de pomp en pas het indien nodig aan. Ga hiervoor naar de pompinstellingen, selecteer 'Gebruikersinstellingen' en vervolgens 'Wachtwoord'. Het standaardwachtwoord is 1234; als je dit nog gebruikt, overweeg dan om het te wijzigen."
           }
         },
         "pl" : {
@@ -2989,22 +4495,22 @@
             "value" : "Przed rozpoczęciem procesu parowania zaleca się sprawdzenie i w razie potrzeby zaktualizowanie hasła pompy. Można to zrobić, przechodząc do ustawień pompy -> ustawień użytkownika -> hasła. Domyślne hasło to 1234, jeśli jest to twoje hasło, rozważ jego zmianę"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Antes de iniciar o processo de emparelhamento, é recomendável verificar e, se necessário, atualizar a senha da bomba. Para isso, acesse as configurações da bomba -> configurações do usuário -> senha. A senha padrão é 1234; se essa for sua senha, considere alterá-la"
+            "state" : "new",
+            "value" : "Before starting with the pairing process, it is recommended to check, and if needed update, the pump password. You can do this by going to the pump settings -> user settings -> password. The default password is 1234, if this is your password, please consider changing it"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Înainte de a începe procesul de împerechere, este recomandat să verificați și, dacă este necesar, să actualizați parola pompei. Puteți face acest lucru accesând setările pompei -> setări utilizator -> parolă. Parola implicită este 1234, dacă aceasta este parola dumneavoastră, vă rugăm să luați în considerare schimbarea acesteia"
+            "state" : "new",
+            "value" : "Before starting with the pairing process, it is recommended to check, and if needed update, the pump password. You can do this by going to the pump settings -> user settings -> password. The default password is 1234, if this is your password, please consider changing it"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Перед началом процесса сопряжения рекомендуется проверить и при необходимости обновить пароль насоса. Это можно сделать, перейдя в настройки насоса -> настройки пользователя -> пароль. По умолчанию используется пароль 1234, если это ваш пароль, пожалуйста, измените его."
+            "value" : "Перед началом сопряжения рекомендуется проверить и, если требуется, изменить пароль помпы. Для этого перейдите в настройки помпы → пользовательские настройки → пароль. По умолчанию пароль — 1234. Если он у Вас установлен, рекомендуется его изменить"
           }
         },
         "sk" : {
@@ -3025,9 +4531,21 @@
             "value" : "Eşleştirme işlemine başlamadan önce, pompa şifresini kontrol etmeniz ve gerekirse güncellemeniz önerilir. Bunu pompa ayarları -> kullanıcı ayarları -> şifre bölümüne giderek yapabilirsiniz. Varsayılan şifre 1234'tür, şifreniz buysa lütfen değiştirmeyi düşünün"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перед початком процесу сполучення рекомендується перевірити та за необхідності оновити пароль Помпи. Це можна зробити, перейшовши в налаштування помпи -> налаштування користувача -> пароль. За промовчанням використовується пароль 1234, якщо це ваш пароль, будь ласка, змініть його."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Trước khi bắt đầu quá trình ghép nối, bạn nên kiểm tra và nếu cần hãy cập nhật mật khẩu máy bơm. Bạn có thể thực hiện việc này bằng cách vào pump settings -> user settings -> password. Mật khẩu mặc định là 1234, nếu đây là mật khẩu của bạn, vui lòng cân nhắc thay đổi mật khẩu"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Before starting with the pairing process, it is recommended to check, and if needed update, the pump password. You can do this by going to the pump settings -> user settings -> password. The default password is 1234, if this is your password, please consider changing it"
           }
         },
@@ -3048,16 +4566,10 @@
             "value" : "قياس نسبة الجلوكوز في الدم"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Měření glukózy v krvi"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Måling af blodsukker"
+            "value" : "Blodsukkermåling"
           }
         },
         "de" : {
@@ -3086,7 +4598,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Blood glucose Measure"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Blood glucose Measure"
           }
         },
@@ -3096,15 +4614,9 @@
             "value" : "Misura della glicemia"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "血糖測定"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Blood glucose Measure"
           }
         },
@@ -3120,16 +4632,16 @@
             "value" : "Pomiar stężenia glukozy we krwi"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Medição de glicose no sangue"
+            "state" : "new",
+            "value" : "Blood glucose Measure"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Măsurarea glicemiei"
+            "state" : "new",
+            "value" : "Blood glucose Measure"
           }
         },
         "ru" : {
@@ -3156,9 +4668,21 @@
             "value" : "Kan şekeri ölçümü"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вимірювання Рівня Глюкози в Крові"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Kiểm tra đường huyết"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Blood glucose Measure"
           }
         },
@@ -3176,13 +4700,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "بولوس"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus"
+            "value" : "الجرعة"
           }
         },
         "da" : {
@@ -3206,7 +4724,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bolus"
+            "value" : "Lisäannos"
           }
         },
         "fr" : {
@@ -3217,8 +4735,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Bolus"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bólus"
           }
         },
         "it" : {
@@ -3227,13 +4751,7 @@
             "value" : "Bolo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーラス"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bolus"
@@ -3247,19 +4765,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Bolus"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Bolus"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Bolus"
           }
         },
@@ -3283,20 +4801,32 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Bolus"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Болюс"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bolus"
+            "value" : "Liều bolus"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolus Value"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "追加胰岛素"
+            "value" : "大剂量"
           }
         }
       }
@@ -3310,16 +4840,10 @@
             "value" : "كلاهما"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obě stránky"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Begge dele"
+            "value" : "Begge"
           }
         },
         "de" : {
@@ -3348,7 +4872,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Both"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Both"
           }
         },
@@ -3358,15 +4888,9 @@
             "value" : "Entrambi"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "両方"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Both"
           }
         },
@@ -3382,16 +4906,16 @@
             "value" : "Oba"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ambos"
+            "state" : "new",
+            "value" : "Both"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ambele"
+            "state" : "new",
+            "value" : "Both"
           }
         },
         "ru" : {
@@ -3403,7 +4927,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Obe stránky"
+            "value" : "Zvuk a vibrácie"
           }
         },
         "sv" : {
@@ -3418,9 +4942,21 @@
             "value" : "Her ikisi de"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обидва"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Cả hai"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Both"
           }
         },
@@ -3439,12 +4975,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إلغاء"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zrušit"
           }
         },
         "da" : {
@@ -3468,7 +4998,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Peruuta"
+            "value" : "Peru"
           }
         },
         "fr" : {
@@ -3479,29 +5009,23 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Cancel"
           }
         },
-        "hi" : {
+        "hu" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "निरस्त"
+            "value" : "Mégse"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annulla"
+            "value" : "Cancella"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "キャンセル"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Avbryt"
@@ -3510,7 +5034,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annuleren"
+            "value" : "Annuleer"
           }
         },
         "pl" : {
@@ -3519,22 +5043,16 @@
             "value" : "Anuluj"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancelar"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cancelar"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Renunță"
           }
         },
         "ru" : {
@@ -3558,13 +5076,25 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İptal"
+            "value" : "Vazgeç"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відмінити"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hủy bỏ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Cancel"
           }
         },
         "zh-Hans" : {
@@ -3584,16 +5114,10 @@
             "value" : "عمر القنية"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stáří kanyly"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kanylens alder"
+            "value" : "Kanylealder"
           }
         },
         "de" : {
@@ -3622,7 +5146,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Cannula age"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Cannula age"
           }
         },
@@ -3632,15 +5162,9 @@
             "value" : "Età della cannula"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "カニューレ年齢"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Cannula age"
           }
         },
@@ -3656,16 +5180,16 @@
             "value" : "Wiek kaniuli"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idade da cânula"
+            "state" : "new",
+            "value" : "Cannula age"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vârsta canulei"
+            "state" : "new",
+            "value" : "Cannula age"
           }
         },
         "ru" : {
@@ -3692,9 +5216,21 @@
             "value" : "Kanül yaşı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "термін використовування Канюлі"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Cannula age"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Cannula age"
           }
         },
@@ -3713,12 +5249,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "قنية فقط"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pouze kanyla"
           }
         },
         "da" : {
@@ -3753,7 +5283,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Cannula only"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Cannula only"
           }
         },
@@ -3763,15 +5299,9 @@
             "value" : "Solo cannula"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "カニューレのみ"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Cannula only"
           }
         },
@@ -3787,16 +5317,16 @@
             "value" : "Tylko kaniula"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Somente cânula"
+            "state" : "new",
+            "value" : "Cannula only"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Numai canulă"
+            "state" : "new",
+            "value" : "Cannula only"
           }
         },
         "ru" : {
@@ -3823,9 +5353,21 @@
             "value" : "Sadece kanül"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "тільки Канюля"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Chỉ Cannula"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Cannula only"
           }
         },
@@ -3847,16 +5389,10 @@
             "value" : "إعادة تعبئة القنية"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Doplnění kanyly"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Genopfyldning af kanyle"
+            "value" : "Kanylegenopfyldning"
           }
         },
         "de" : {
@@ -3891,7 +5427,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Cannula refill"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Cannula refill"
           }
         },
@@ -3901,15 +5443,9 @@
             "value" : "Ricarica della cannula"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "カニューレ再充填"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Cannula refill"
           }
         },
@@ -3925,16 +5461,16 @@
             "value" : "Uzupełnianie kaniuli"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recarga de cânula"
+            "state" : "new",
+            "value" : "Cannula refill"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reîncărcare canulă"
+            "state" : "new",
+            "value" : "Cannula refill"
           }
         },
         "ru" : {
@@ -3961,9 +5497,21 @@
             "value" : "Kanül dolumu"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "заправка Канюлі"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Nạp Cannula"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Cannula refill"
           }
         },
@@ -3982,12 +5530,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "شيك شافت"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zkontrolujte řetěz"
           }
         },
         "da" : {
@@ -4022,7 +5564,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Check chaft"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Check chaft"
           }
         },
@@ -4032,15 +5580,9 @@
             "value" : "Controllare il fusto"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "シャフトのチェック"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Check chaft"
           }
         },
@@ -4056,16 +5598,16 @@
             "value" : "Sprawdź wał"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificar o eixo"
+            "state" : "new",
+            "value" : "Check chaft"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificarea chaft"
+            "state" : "new",
+            "value" : "Check chaft"
           }
         },
         "ru" : {
@@ -4092,9 +5634,21 @@
             "value" : "Şaftı kontrol edin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перевірте вал"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Check chaft"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Check chaft"
           }
         },
@@ -4113,12 +5667,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "افحص المضخة وحاول مرة أخرى"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zkontrolujte čerpadlo a zkuste to znovu"
           }
         },
         "da" : {
@@ -4153,7 +5701,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Check the pump and try again"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Check the pump and try again"
           }
         },
@@ -4163,15 +5717,9 @@
             "value" : "Controllare la pompa e riprovare"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプをチェックし、もう一度試す"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Check the pump and try again"
           }
         },
@@ -4187,22 +5735,22 @@
             "value" : "Sprawdź pompę i spróbuj ponownie"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifique a bomba e tente novamente"
+            "state" : "new",
+            "value" : "Check the pump and try again"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificați pompa și încercați din nou"
+            "state" : "new",
+            "value" : "Check the pump and try again"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Проверьте насос и повторите попытку."
+            "value" : "Проверьте помпу и повторите попытку"
           }
         },
         "sk" : {
@@ -4223,9 +5771,21 @@
             "value" : "Pompayı kontrol edin ve tekrar deneyin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перевірте Помпу та повторіть спробу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Kiểm tra máy bơm và thử lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Check the pump and try again"
           }
         },
@@ -4244,12 +5804,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "افحص الخزان والحقن وحاول مرة أخرى"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zkontrolujte zásobník a infuzi a zkuste to znovu."
           }
         },
         "da" : {
@@ -4284,7 +5838,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Check the reservoir and infus and try again"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Check the reservoir and infus and try again"
           }
         },
@@ -4294,15 +5854,9 @@
             "value" : "Controllare il serbatoio e l'infusore e riprovare."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "リザーバーと輸液を確認し、もう一度試してください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Check the reservoir and infus and try again"
           }
         },
@@ -4318,22 +5872,22 @@
             "value" : "Sprawdź zbiornik i infuzję, a następnie spróbuj ponownie."
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verifique o reservatório e a infusão e tente novamente"
+            "state" : "new",
+            "value" : "Check the reservoir and infus and try again"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificați rezervorul și infuzați și încercați din nou"
+            "state" : "new",
+            "value" : "Check the reservoir and infus and try again"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Проверьте резервуар, влейте воду и повторите попытку."
+            "value" : "Проверьте резервуар, заполните и повторите попытку"
           }
         },
         "sk" : {
@@ -4354,9 +5908,21 @@
             "value" : "Hazneyi ve infüzyonu kontrol edin ve tekrar deneyin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перевірте Резервуар і інфузійний набір та повторіть спробу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Hãy Kiểm tra bình chứa và dây truyền và thử lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Check the reservoir and infus and try again"
           }
         },
@@ -4377,16 +5943,10 @@
             "value" : "تم الفحص في"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zkontrolováno v"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kontrolleret på"
+            "value" : "Tjekket kl."
           }
         },
         "de" : {
@@ -4415,7 +5975,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Checked at"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Checked at"
           }
         },
@@ -4425,22 +5991,16 @@
             "value" : "Controllato presso"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "でチェックした。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Checked at"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gecontroleerd op"
+            "value" : "Gecontroleerd bij"
           }
         },
         "pl" : {
@@ -4449,16 +6009,16 @@
             "value" : "Sprawdzono w"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificado em"
+            "state" : "new",
+            "value" : "Checked at"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verificat la"
+            "state" : "new",
+            "value" : "Checked at"
           }
         },
         "ru" : {
@@ -4470,7 +6030,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Skontrolované na"
+            "value" : "Skontrolované o"
           }
         },
         "sv" : {
@@ -4485,9 +6045,21 @@
             "value" : "Kontrol edildi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перевірено в"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã kiểm tra tại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Checked at"
           }
         },
@@ -4508,16 +6080,10 @@
             "value" : "فشلت عملية الفحص. حاول مرة أخرى"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kontrolní součet selhal. Zkuste to znovu"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Checksum mislykkedes. Prøv igen"
+            "value" : "Ukorrekt kontrolsum. Forsøg igen"
           }
         },
         "de" : {
@@ -4546,7 +6112,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Checksum failed. Try again"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Checksum failed. Try again"
           }
         },
@@ -4556,15 +6128,9 @@
             "value" : "Checksum fallito. Riprovare"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "チェックサムに失敗しました。再試行してください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Checksum failed. Try again"
           }
         },
@@ -4580,22 +6146,22 @@
             "value" : "Suma kontrolna nie powiodła się. Spróbuj ponownie"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha na soma de verificação. Tente novamente"
+            "state" : "new",
+            "value" : "Checksum failed. Try again"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Checksum-ul a eșuat. Încercați din nou"
+            "state" : "new",
+            "value" : "Checksum failed. Try again"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Не удалось получить контрольную сумму. Попробуйте еще раз"
+            "value" : "Ошибка контрольной суммы. Попробуйте еще раз"
           }
         },
         "sk" : {
@@ -4616,9 +6182,21 @@
             "value" : "Checksum başarısız oldu. Tekrar deneyin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помилка контрольної суми. Спробуйте знову"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Kiểm tra tổng không thành công. Hãy thử lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Checksum failed. Try again"
           }
         },
@@ -4636,13 +6214,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "التكوين"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurace"
+            "value" : "ضبط"
           }
         },
         "da" : {
@@ -4660,13 +6232,13 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Configuración"
+            "value" : "Configuracion"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Konfigurointi"
+            "state" : "new",
+            "value" : "Configuration"
           }
         },
         "fr" : {
@@ -4677,50 +6249,50 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Configuration"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Beállítások"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Configurazione"
+            "value" : "Impostazioni"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "構成"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuration"
+            "value" : "Oppsett"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Configuratie"
+            "value" : "Instellingen"
           }
         },
         "pl" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Configuration"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "Konfiguracja"
+            "value" : "Ajustes"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Configuração"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurație"
+            "value" : "Ajustes"
           }
         },
         "ru" : {
@@ -4732,7 +6304,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Konfigurácia"
+            "value" : "Nastavenie"
           }
         },
         "sv" : {
@@ -4744,12 +6316,24 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Konfigürasyon"
+            "value" : "Yapılandırma"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Налаштування"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Cấu hình"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Configuration"
           }
         },
@@ -4763,6 +6347,132 @@
     },
     "Connect" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "توصيل"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Forbind"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbinden"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectar"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Yhdistä"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se connecter"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connect"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Csatlakozás"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Connetti"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koble til"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbinden"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Połącz"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectar"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectar"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подключить"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pripojiť"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Anslut"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bağlan"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підключити"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kết nối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connect"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4776,14 +6486,8 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "متصل"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Připojeno"
+            "state" : "new",
+            "value" : "Connected"
           }
         },
         "da" : {
@@ -4819,49 +6523,49 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "מחובר"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Connected"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Collegato"
+            "value" : "Connesso"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "接続済み"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Connected"
+            "value" : "Tilkoblet"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aangesloten"
+            "value" : "Verbonden"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Połączony"
+            "value" : "Połączono"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connected"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conectado"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectat"
           }
         },
         "ru" : {
@@ -4885,12 +6589,24 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bağlı"
+            "value" : "Bağlandı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Під'єднаний"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã kết nối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Connected"
           }
         },
@@ -4907,74 +6623,68 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "التوصيل"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Připojení"
+            "state" : "new",
+            "value" : "Connecting"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Forbindelse"
+            "value" : "Tilslutter"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verbinden Sie"
+            "value" : "Verbinden"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Conexión"
+            "value" : "Conectando"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Yhdistäminen"
+            "value" : "Yhdistetään"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Connexion"
+            "value" : "Connexion en cours"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "מתחבר"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Connecting"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Collegamento"
+            "value" : "In fase di Connessione"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "接続"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tilkobling"
+            "value" : "Kobler til"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aansluiten op"
+            "value" : "Bezig met verbinden"
           }
         },
         "pl" : {
@@ -4983,16 +6693,16 @@
             "value" : "Łączenie"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Connecting"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Conexão"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Conectarea"
+            "value" : "Conectando"
           }
         },
         "ru" : {
@@ -5004,31 +6714,43 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pripojenie"
+            "value" : "Pripája sa"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Anslutning"
+            "value" : "Ansluter"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bağlantı"
+            "value" : "Bağlanıyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Під'єднання"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đang kết nối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Connecting"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "连接"
+            "value" : "正在连接"
           }
         }
       }
@@ -5042,12 +6764,6 @@
             "value" : "تابع"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pokračovat"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5057,13 +6773,13 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Weiter"
+            "value" : "Fortsetzen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Continúe en"
+            "value" : "Continuar"
           }
         },
         "fi" : {
@@ -5080,7 +6796,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Continue"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Continue"
           }
         },
@@ -5090,13 +6812,7 @@
             "value" : "Continua"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "続ける"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fortsett"
@@ -5105,7 +6821,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ga verder"
+            "value" : "Vervolg"
           }
         },
         "pl" : {
@@ -5114,16 +6830,16 @@
             "value" : "Kontynuuj"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Continue"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continuar"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Continuați"
           }
         },
         "ru" : {
@@ -5150,9 +6866,21 @@
             "value" : "Devam et"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Продовжити"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Tiếp tục"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Continue"
           }
         },
@@ -5171,12 +6899,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تم الوصول إلى الحد اليومي"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dosažení denního limitu"
           }
         },
         "da" : {
@@ -5211,7 +6933,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Daily limit reached"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Daily limit reached"
           }
         },
@@ -5221,16 +6949,10 @@
             "value" : "Limite giornaliero raggiunto"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "1日の制限に達した"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Daglig grense nådd"
+            "state" : "new",
+            "value" : "Daily limit reached"
           }
         },
         "nl" : {
@@ -5245,16 +6967,16 @@
             "value" : "Osiągnięto limit dzienny"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limite diário atingido"
+            "state" : "new",
+            "value" : "Daily limit reached"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limita zilnică atinsă"
+            "state" : "new",
+            "value" : "Daily limit reached"
           }
         },
         "ru" : {
@@ -5281,9 +7003,21 @@
             "value" : "Günlük limite ulaşıldı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Денний ліміт досягнуто"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đạt giới hạn hàng ngày"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Daily limit reached"
           }
         },
@@ -5299,12 +7033,6 @@
       "comment" : "dana-i option text for DanaKitSetupView",
       "localizations" : {
         "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "دانا-أنا"
-          }
-        },
-        "cs" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dana-i"
@@ -5324,25 +7052,31 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Dana-i"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Dana-i"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Dana-i"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Dana-i"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Dana-i"
           }
         },
@@ -5352,15 +7086,9 @@
             "value" : "Dana-i"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダナアイ"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Dana-i"
           }
         },
@@ -5372,26 +7100,26 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Dana-i"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Dana-i"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dana-i"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Dana-i"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Дана-и"
+            "value" : "Dana-i"
           }
         },
         "sk" : {
@@ -5408,6 +7136,12 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Dana-i"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
             "value" : "Dana-i"
           }
@@ -5415,6 +7149,12 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Dana-i"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Dana-i"
           }
         },
@@ -5433,12 +7173,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إعداد Dana-i/RS"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nastavení systému Dana-i/RS"
           }
         },
         "da" : {
@@ -5473,7 +7207,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Dana-i/RS Setup"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Dana-i/RS Setup"
           }
         },
@@ -5483,16 +7223,10 @@
             "value" : "Configurazione di Dana-i/RS"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dana-i/RSセットアップ"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dana-i/RS-oppsett"
+            "state" : "new",
+            "value" : "Dana-i/RS Setup"
           }
         },
         "nl" : {
@@ -5507,16 +7241,16 @@
             "value" : "Konfiguracja Dana-i/RS"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuração de Dana-i/RS"
+            "state" : "new",
+            "value" : "Dana-i/RS Setup"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurarea Dana-i/RS"
+            "state" : "new",
+            "value" : "Dana-i/RS Setup"
           }
         },
         "ru" : {
@@ -5543,9 +7277,21 @@
             "value" : "Dana-i/RS Kurulumu"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Налаштування Dana-i/RS"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Thiết lập Dana-i/RS"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Dana-i/RS Setup"
           }
         },
@@ -5564,12 +7310,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تم العثور على Dana-RS v3!"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dana-RS v3 nalezen!"
           }
         },
         "da" : {
@@ -5604,7 +7344,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Dana-RS v3 found!"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Dana-RS v3 found!"
           }
         },
@@ -5614,16 +7360,10 @@
             "value" : "Dana-RS v3 trovato!"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dana-RS v3が見つかった！"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dana-RS v3 funnet!"
+            "state" : "new",
+            "value" : "Dana-RS v3 found!"
           }
         },
         "nl" : {
@@ -5638,28 +7378,28 @@
             "value" : "Dana-RS v3 znaleziony!"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dana-RS v3 encontrado!"
+            "state" : "new",
+            "value" : "Dana-RS v3 found!"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dana-RS v3 găsit!"
+            "state" : "new",
+            "value" : "Dana-RS v3 found!"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dana-RS v3 найден!"
+            "value" : "Dana-RS v3 найдена!"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dana-RS v3 nájdený!"
+            "value" : "Dana-RS v3 nájdená!"
           }
         },
         "sv" : {
@@ -5674,9 +7414,21 @@
             "value" : "Dana-RS v3 bulundu!"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dana-RS v3 знайдено!"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã tìm thấy Dana-RS v3!"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Dana-RS v3 found!"
           }
         },
@@ -5697,12 +7449,6 @@
             "value" : "DanaRS-v1"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DanaRS-v1"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5717,25 +7463,31 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "DanaRS-v1"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "DanaRS-v1"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "DanaRS-v1"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "DanaRS-v1"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "DanaRS-v1"
           }
         },
@@ -5745,15 +7497,9 @@
             "value" : "DanaRS-v1"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダナRS-v1"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "DanaRS-v1"
           }
         },
@@ -5765,19 +7511,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "DanaRS-v1"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "DanaRS-v1"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "DanaRS-v1"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "DanaRS-v1"
           }
         },
@@ -5801,6 +7547,12 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "DanaRS-v1"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
             "value" : "DanaRS-v1"
           }
@@ -5811,9 +7563,15 @@
             "value" : "DanaRS-v1"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DanaRS-v1"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "DanaRS-v1"
           }
         }
@@ -5828,12 +7586,6 @@
             "value" : "DanaRS-v3"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "DanaRS-v3"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5848,25 +7600,31 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "DanaRS-v3"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "DanaRS-v3"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "DanaRS-v3"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "DanaRS-v3"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "DanaRS-v3"
           }
         },
@@ -5876,15 +7634,9 @@
             "value" : "DanaRS-v3"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダナRS-v3"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "DanaRS-v3"
           }
         },
@@ -5896,19 +7648,19 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "DanaRS-v3"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "DanaRS-v3"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "DanaRS-v3"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "DanaRS-v3"
           }
         },
@@ -5932,6 +7684,12 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "DanaRS-v3"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
             "value" : "DanaRS-v3"
           }
@@ -5942,9 +7700,15 @@
             "value" : "DanaRS-v3"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DanaRS-v3"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "DanaRS-v3"
           }
         }
@@ -5958,12 +7722,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "يوم (أيام)"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "den(y)"
           }
         },
         "da" : {
@@ -6004,26 +7762,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "day(s)"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "day(s)"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/giorno"
+            "value" : "giorno/i"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "日"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "dag(er)"
+            "state" : "new",
+            "value" : "day(s)"
           }
         },
         "nl" : {
@@ -6038,22 +7796,22 @@
             "value" : "dzień(dni)"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "dia(s)"
+            "state" : "new",
+            "value" : "day(s)"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "zi(e)"
+            "state" : "new",
+            "value" : "day(s)"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "день(ы)"
+            "value" : "день(и)"
           }
         },
         "sk" : {
@@ -6074,9 +7832,21 @@
             "value" : "gün(ler)"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "день(-ів)"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "day(s)"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "day(s)"
           }
         },
@@ -6090,10 +7860,130 @@
     },
     "DEBUG: Bolus action" : {
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "DEBUG: Bolus-handling"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Bolus action"
           }
         },
         "zh-Hans" : {
@@ -6106,10 +7996,136 @@
     },
     "DEBUG: Temp basal action" : {
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "DEBUG: Midlertidig basal handling"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "DEBUG: Temp basal action"
           }
         }
       }
@@ -6121,143 +8137,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "حذف المضخة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odstranit čerpadlo"
-          }
-        },
-        "da" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slet pumpen"
-          }
-        },
-        "de" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pumpe löschen"
-          }
-        },
-        "es" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Borrar bomba"
-          }
-        },
-        "fi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista pumppu"
-          }
-        },
-        "fr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Supprimer la pompe"
-          }
-        },
-        "he" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete pump"
-          }
-        },
-        "it" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eliminare la pompa"
-          }
-        },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプの削除"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slett pumpe"
-          }
-        },
-        "nl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pomp verwijderen"
-          }
-        },
-        "pl" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuń pompę"
-          }
-        },
-        "pt_BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Excluir bomba"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ștergeți pompa"
-          }
-        },
-        "ru" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Удалить насос"
-          }
-        },
-        "sk" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vymazať čerpadlo"
-          }
-        },
-        "sv" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ta bort pumpen"
-          }
-        },
-        "tr" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pompayı sil"
-          }
-        },
-        "vi" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete pump"
-          }
-        },
-        "zh-Hans" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "删除泵"
-          }
-        }
-      }
-    },
-    "Delete Pump" : {
-      "comment" : "Label for PumpManager deletion button",
-      "localizations" : {
-        "ar" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "حذف المضخة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odstranit čerpadlo"
           }
         },
         "da" : {
@@ -6292,8 +8171,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Delete Pump"
+            "state" : "new",
+            "value" : "Delete pump"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete pump"
           }
         },
         "it" : {
@@ -6302,16 +8187,10 @@
             "value" : "Eliminare la pompa"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプの削除"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Slette pumpe"
+            "state" : "new",
+            "value" : "Delete pump"
           }
         },
         "nl" : {
@@ -6326,34 +8205,171 @@
             "value" : "Usuń pompę"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Excluir bomba"
+            "state" : "new",
+            "value" : "Delete pump"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ștergeți pompa"
+            "state" : "new",
+            "value" : "Delete pump"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Удалить насос"
+            "value" : "Удалить помпу"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Odstrániť čerpadlo"
+            "value" : "Odstrániť pumpu"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ta bort pump"
+            "value" : "Ta bort pumpen"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pompayı sil"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видалити помпу"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xóa bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete pump"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "删除泵"
+          }
+        }
+      }
+    },
+    "Delete Pump" : {
+      "comment" : "Label for PumpManager deletion button",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "حذف المضخة"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slet pumpe"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpe löschen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eliminar Microinfusora"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poista pumppu"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Supprimer la pompe"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Pump"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Pump"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancella Microinfusore"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slette pumpe"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verwijder de pomp"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Usuń pompę"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Delete Pump"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deletar Bomba"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Удалить помпу"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odstrániť pumpu"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Radera pump"
           }
         },
         "tr" : {
@@ -6362,9 +8378,21 @@
             "value" : "Pompayı Sil"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Видалити помпу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Xóa bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Delete Pump"
           }
         },
@@ -6383,12 +8411,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "سرعة التوصيل"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rychlost dodání"
           }
         },
         "da" : {
@@ -6423,7 +8445,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Delivery speed"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Delivery speed"
           }
         },
@@ -6433,16 +8461,10 @@
             "value" : "Velocità di consegna"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "配送スピード"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Leveringshastighet"
+            "state" : "new",
+            "value" : "Delivery speed"
           }
         },
         "nl" : {
@@ -6457,28 +8479,28 @@
             "value" : "Szybkość dostawy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velocidade de entrega"
+            "state" : "new",
+            "value" : "Delivery speed"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Viteza de livrare"
+            "state" : "new",
+            "value" : "Delivery speed"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Скорость доставки"
+            "value" : "Скорость подачи"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rýchlosť dodania"
+            "value" : "Rýchlosť dávkovania"
           }
         },
         "sv" : {
@@ -6493,9 +8515,21 @@
             "value" : "Teslimat hızı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Швидкість доставки"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Delivery speed"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Delivery speed"
           }
         },
@@ -6509,10 +8543,130 @@
     },
     "Device found!" : {
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Enhet funnet!"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enhet hittad!"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Device found!"
           }
         },
         "zh-Hans" : {
@@ -6533,16 +8687,10 @@
             "value" : "تعطيل مزامنة البلعة؟"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zakázat synchronizaci bolusu?"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deaktivere bolus-synkronisering?"
+            "value" : "Deaktivér bolus-synkning?"
           }
         },
         "de" : {
@@ -6577,7 +8725,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Disable bolus syncing?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Disable bolus syncing?"
           }
         },
@@ -6587,16 +8741,10 @@
             "value" : "Disattivare la sincronizzazione del bolo?"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーラスの同期を無効にしますか？"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deaktiver bolussynkronisering?"
+            "state" : "new",
+            "value" : "Disable bolus syncing?"
           }
         },
         "nl" : {
@@ -6611,16 +8759,16 @@
             "value" : "Wyłączyć synchronizację bolusa?"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desativar a sincronização de bolus?"
+            "state" : "new",
+            "value" : "Disable bolus syncing?"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dezactivați sincronizarea bolusurilor?"
+            "state" : "new",
+            "value" : "Disable bolus syncing?"
           }
         },
         "ru" : {
@@ -6647,32 +8795,164 @@
             "value" : "Bolus senkronizasyonunu devre dışı mı bırakayım?"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вимкнути синхронізацію болюсу?"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Tắt đồng bộ bolus?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Disable bolus syncing?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "禁用追加胰岛素同步？"
+            "value" : "禁用栓剂同步？"
           }
         }
       }
     },
     "Disconnect" : {
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Koble fra"
+            "value" : "Verbindung trennen"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verbinding verbreken"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отключить"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odpojiť"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koppla från"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Роз'єднати"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ngắt kết nối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnect"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "断开连接"
+            "state" : "new",
+            "value" : "Disconnect"
           }
         }
       }
@@ -6686,16 +8966,10 @@
             "value" : "قطع الاتصال بالمضخة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odpojení od čerpadla"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Afbryd forbindelsen til pumpen"
+            "value" : "Frakobl fra pumpen"
           }
         },
         "de" : {
@@ -6724,7 +8998,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Disconnect from pump"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Disconnect from pump"
           }
         },
@@ -6734,16 +9014,10 @@
             "value" : "Scollegare dalla pompa"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプから切り離す"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Koble fra pumpen"
+            "state" : "new",
+            "value" : "Disconnect from pump"
           }
         },
         "nl" : {
@@ -6758,22 +9032,22 @@
             "value" : "Odłączyć od pompy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desconectar da bomba"
+            "state" : "new",
+            "value" : "Disconnect from pump"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deconectați de la pompă"
+            "state" : "new",
+            "value" : "Disconnect from pump"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Отсоедините от насоса"
+            "value" : "Отключить от помпы"
           }
         },
         "sk" : {
@@ -6794,9 +9068,21 @@
             "value" : "Pompa bağlantısını kesin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Від'єднати від помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Ngắt kết nối từ máy bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Disconnect from pump"
           }
         },
@@ -6813,14 +9099,8 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "غير متصل"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odpojení"
+            "state" : "new",
+            "value" : "Disconnected"
           }
         },
         "da" : {
@@ -6844,7 +9124,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Irrotettu"
+            "value" : "Ei yhteydessä"
           }
         },
         "fr" : {
@@ -6856,6 +9136,12 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "מנותק"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Disconnected"
           }
         },
@@ -6865,13 +9151,7 @@
             "value" : "Disconnesso"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "切断"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Frakoblet"
@@ -6886,7 +9166,13 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Odłączony"
+            "value" : "Rozłączony"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Disconnected"
           }
         },
         "pt_BR" : {
@@ -6895,16 +9181,10 @@
             "value" : "Desconectado"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deconectat"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Отключено"
+            "value" : "Разъединено"
           }
         },
         "sk" : {
@@ -6925,16 +9205,28 @@
             "value" : "Bağlantı kesildi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Від’єднано"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã ngắt kết nối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Disconnected"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "断开"
+            "value" : "已断开连接"
           }
         }
       }
@@ -6946,12 +9238,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "قطع الاتصال..."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odpojení..."
           }
         },
         "da" : {
@@ -6986,7 +9272,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Disconnecting..."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Disconnecting..."
           }
         },
@@ -6996,16 +9288,10 @@
             "value" : "Disconnessione..."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "切断..."
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kobler fra..."
+            "state" : "new",
+            "value" : "Disconnecting..."
           }
         },
         "nl" : {
@@ -7020,16 +9306,16 @@
             "value" : "Odłączanie..."
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desconectando..."
+            "state" : "new",
+            "value" : "Disconnecting..."
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deconectarea..."
+            "state" : "new",
+            "value" : "Disconnecting..."
           }
         },
         "ru" : {
@@ -7056,9 +9342,21 @@
             "value" : "Bağlantı kesiliyor."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відключення..."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đang ngắt kết nối..."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Disconnecting..."
           }
         },
@@ -7072,10 +9370,130 @@
     },
     "Do bolus" : {
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gjør bolus"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Utför bolus"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Do bolus"
           }
         },
         "zh-Hans" : {
@@ -7093,12 +9511,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "هل ترغب في تلقي إشعار عندما تكون المضخة مفصولة لفترة زمنية محددة؟"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chcete dostávat upozornění, když je čerpadlo delší dobu odpojeno?"
           }
         },
         "da" : {
@@ -7133,7 +9545,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Do you wish to receive a notification when the pump is longer disconnected for a specific time?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Do you wish to receive a notification when the pump is longer disconnected for a specific time?"
           }
         },
@@ -7143,16 +9561,10 @@
             "value" : "Si desidera ricevere una notifica quando la pompa viene scollegata per un periodo di tempo specifico?"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプが特定の時間切断された場合に通知を受け取りたいですか？"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ønsker du å motta et varsel når pumpen ikke lenger er koblet fra i en bestemt periode?"
+            "state" : "new",
+            "value" : "Do you wish to receive a notification when the pump is longer disconnected for a specific time?"
           }
         },
         "nl" : {
@@ -7167,22 +9579,22 @@
             "value" : "Czy chcesz otrzymywać powiadomienia, gdy pompa zostanie odłączona na określony czas?"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Deseja receber uma notificação quando a bomba for desconectada por mais tempo por um período específico?"
+            "state" : "new",
+            "value" : "Do you wish to receive a notification when the pump is longer disconnected for a specific time?"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Doriți să primiți o notificare atunci când pompa este deconectată pentru o anumită perioadă de timp?"
+            "state" : "new",
+            "value" : "Do you wish to receive a notification when the pump is longer disconnected for a specific time?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Хотите ли вы получать уведомление, когда насос отключается на определенное время?"
+            "value" : "Хотите ли вы получать уведомление, когда помпа отключена в течение определенного времени?"
           }
         },
         "sk" : {
@@ -7203,9 +9615,21 @@
             "value" : "Pompanın bağlantısı belirli bir süre için kesildiğinde bir bildirim almak istiyor musunuz?"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Чи бажаєте ви отримувати сповіщення, коли Помпу буде відключено на певний час?"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Bạn có muốn nhận thông báo khi máy bơm không được ngắt kết nối trong một khoảng thời gian cụ thể không?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Do you wish to receive a notification when the pump is longer disconnected for a specific time?"
           }
         },
@@ -7219,10 +9643,130 @@
     },
     "Done" : {
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "تمّ"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fertig"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hecho"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valmis"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Terminé"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Done"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kész"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fine"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ferdig"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Done"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готово"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hotovo"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klar"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tamam"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готово"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Xong"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Done"
           }
         },
         "zh-Hans" : {
@@ -7242,16 +9786,10 @@
             "value" : "أثناء عملية الاقتران، سيعرض جهاز Dana-i الخاص بك مطالبة بالاقتران بينما سيعرض جهاز iPhone الخاص بك مطالبة برمز الاقتران. عند قيامك بالضخ، حدد موافق واكتب الرمز المكون من 6 أرقام في شاشة جهاز الآيفون الخاص بك. بعد ذلك، يكون %1$@ جاهزًا للتواصل مع جهاز Dana-i الخاص بك"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Během procesu párování se na displeji zařízení Dana-i zobrazí výzva ke spárování, zatímco na displeji iPhonu se zobrazí výzva k zadání párovacího kódu. Na pumpě zvolte OK a zadejte šestimístný kód na obrazovce iPhonu. Poté je stránka %1$@ připravena komunikovat s vaším zařízením Dana-i."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Under parringsprocessen vil din Dana-i vise en parringsmeddelelse, mens din iPhone vil vise en meddelelse om en parringskode. Vælg OK på din pumpe, og skriv den 6-cifrede kode på skærmen på din iPhone. Herefter er %1$@ klar til at kommunikere med din Dana-i."
+            "value" : "Dana-i vil under parringsprocessen vil vise en parringsprompt, mens iPhonen vil vise en prompt om en parringskode. Vælg OK på pumpen, og angiv den 6-cifrede kode på skærmen på iPhonen. %1$@ vil herefter være klar til at kommunikere med Dana-i"
           }
         },
         "de" : {
@@ -7280,7 +9818,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "During the pairing process, your Dana-i will show a pairing prompt while your iPhone will show a prompt for a pairing code. On you pump, select OK and type the 6-digit code in screen on your iPhone. After that, %1$@ is ready to communicate with your Dana-i"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "During the pairing process, your Dana-i will show a pairing prompt while your iPhone will show a prompt for a pairing code. On you pump, select OK and type the 6-digit code in screen on your iPhone. After that, %1$@ is ready to communicate with your Dana-i"
           }
         },
@@ -7290,16 +9834,10 @@
             "value" : "Durante il processo di accoppiamento, il Dana-i mostrerà una richiesta di accoppiamento, mentre l'iPhone mostrerà una richiesta di codice di accoppiamento. Selezionare OK e digitare il codice di 6 cifre sullo schermo dell'iPhone. A questo punto, %1$@ è pronto a comunicare con il vostro Dana-i."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ペアリング中、Dana-iにはペアリングのプロンプトが表示され、iPhoneにはペアリングコードのプロンプトが表示されます。あなたのポンプでOKを選択し、iPhoneの画面に6桁のコードを入力します。その後、 %1$@ 、Dana-iと通信する準備が整います。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Under sammenkoblingsprosessen vil Dana-i vise en sammenkoblingsmelding mens iPhone vil vise en melding om en sammenkoblingskode. På pumpen velger du OK og skriver inn den 6-sifrede koden på skjermen på iPhone. Deretter %1$@ er klar til å kommunisere med din Dana-i"
+            "state" : "new",
+            "value" : "During the pairing process, your Dana-i will show a pairing prompt while your iPhone will show a prompt for a pairing code. On you pump, select OK and type the 6-digit code in screen on your iPhone. After that, %1$@ is ready to communicate with your Dana-i"
           }
         },
         "nl" : {
@@ -7314,22 +9852,22 @@
             "value" : "Podczas procesu parowania Dana-i wyświetli monit o sparowanie, a iPhone wyświetli monit o kod parowania. Wybierz OK i wpisz 6-cyfrowy kod na ekranie iPhone'a. Następnie strona %1$@ jest gotowa do komunikacji z urządzeniem Dana-i."
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Durante o processo de emparelhamento, a Dana-i mostrará uma solicitação de emparelhamento, enquanto o iPhone mostrará uma solicitação de código de emparelhamento. Em sua bomba, selecione OK e digite o código de 6 dígitos na tela do iPhone. Depois disso, o site %1$@ estará pronto para se comunicar com sua Dana-i"
+            "state" : "new",
+            "value" : "During the pairing process, your Dana-i will show a pairing prompt while your iPhone will show a prompt for a pairing code. On you pump, select OK and type the 6-digit code in screen on your iPhone. After that, %1$@ is ready to communicate with your Dana-i"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "În timpul procesului de împerechere, Dana-i va afișa o solicitare de împerechere, în timp ce iPhone-ul va afișa o solicitare pentru un cod de împerechere. Pe pompă, selectați OK și tastați codul de 6 cifre în ecranul de pe iPhone. După aceea, %1$@ este gata să comunice cu Dana-i"
+            "state" : "new",
+            "value" : "During the pairing process, your Dana-i will show a pairing prompt while your iPhone will show a prompt for a pairing code. On you pump, select OK and type the 6-digit code in screen on your iPhone. After that, %1$@ is ready to communicate with your Dana-i"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Во время процесса сопряжения на экране Dana-i появится запрос на сопряжение, а на экране iPhone - запрос на код сопряжения. Выберите OK и введите 6-значный код на экране iPhone. После этого %1$@ будет готов к общению с вашим Dana-i."
+            "value" : "Во время процесса сопряжения на экране Dana-i появится запрос на сопряжение, а на экране iPhone - запрос на код сопряжения. Выберите OK и введите 6-значный код на экране iPhone. После этого %1$@ будет готов к работе с Вашей Dana-i"
           }
         },
         "sk" : {
@@ -7350,9 +9888,21 @@
             "value" : "Eşleştirme işlemi sırasında Dana-i cihazınız bir eşleştirme istemi gösterirken iPhone'unuz bir eşleştirme kodu istemi gösterecektir. Pompanızda Tamam'ı seçin ve 6 haneli kodu iPhone'unuzdaki ekrana yazın. Bundan sonra, %1$@ Dana-i'niz ile iletişim kurmaya hazırdır"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Під час сполучення на екрані Dana-i з'явиться запит на пару, а на екрані iPhone - запит на код сполучення. Виберіть OK та введіть 6-значний код на екрані iPhone. Після цього %1$@ буде готовий до роботи з Dana-i."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Trong quá trình ghép nối, Dana-i của bạn sẽ hiển thị lời nhắc ghép nối trong khi iPhone của bạn sẽ hiển thị lời nhắc nhập mã ghép nối. Trên máy bơm của bạn, hãy chọn OK và nhập mã gồm 6 chữ số vào màn hình trên iPhone của bạn. Sau đó, %1$@ đã sẵn sàng giao tiếp với Dana-i của bạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "During the pairing process, your Dana-i will show a pairing prompt while your iPhone will show a prompt for a pairing code. On you pump, select OK and type the 6-digit code in screen on your iPhone. After that, %1$@ is ready to communicate with your Dana-i"
           }
         },
@@ -7367,16 +9917,136 @@
     "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1" : {
       "comment" : "Subtext for danars v1 (1: appName)",
       "localizations" : {
-        "nb" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Under sammenkoblingsprosessen vil DanaRS v1 vise en sammenkoblingsmelding, mens iPhone vil vise en melding om en sammenkoblingskode. Velg OK på pumpen, og skriv inn koden på iPhone. Etter dette er %1$@ klar til å kommunisere med DanaRS v1"
+            "value" : "أثناء عملية الإقران، ستظهر رسالة تأكيد على جهاز DanaRS v1 الخاص بك، في حين سيظهر على جهاز iPhone الخاص بك مربع لإدخال رمز الإقران. على مضخة الإنسولين، اضغط على \"موافق\" ثم أدخل الرمز المعروض في جهاز iPhone. بعد ذلك، يصبح %1$@ جاهزًا للتواصل مع جهاز DanaRS v1 الخاص بك"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tijdens het koppelingsproces toont je DanaRS v1 een koppelingsverzoek, terwijl je iPhone om een koppelingscode vraagt. Selecteer 'OK' op je pomp en voer de code in op je iPhone. Daarna is %1$@ klaar om te communiceren met je DanaRS v1"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Во время процесса сопряжения на вашей DanaRS v1 появится запрос на сопряжение, а на вашем iPhone отобразится запрос на ввод кода сопряжения. На помпе выберите «ОК» и введите код на вашем iPhone. После этого %1$@ будет готов к взаимодействию с вашей DanaRS v1"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Počas procesu párovania zobrazí tvoja DanaRS v1 výzvu na párovanie, zatiaľ čo tvoj iPhone zobrazí výzvu na zadanie párovacieho kódu. Na pumpe zvoľ OK a zadaj kód do svojho iPhonu. Potom bude %1$@ pripravený komunikovať s tvojou DanaRS v1"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Under parkopplingsprocessen kommer DanaRS v1 att visa en parkopplingsfråga medan din iPhone kommer att visa en fråga om en parkopplingskod. Välj OK på din pump och skriv in koden på din iPhone. Efter det är %1$@ redo att kommunicera med din DanaRS v1"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Під час процесу створення пари на вашому DanaRS v1 відображатиметься запит на створення пари, а на вашому iPhone – код сполучення. На помпі виберіть OK і введіть код на своєму iPhone. Після цього %1$@ готовий до зв’язку з DanaRS v1"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trong quá trình ghép nối, DanaRS v1 của bạn sẽ hiển thị lời nhắc ghép nối trong khi iPhone của bạn sẽ hiển thị lời nhắc nhập mã ghép nối. Trên máy bơm của bạn, hãy chọn OK và nhập mã trên iPhone của bạn. Sau đó, %1$@ đã sẵn sàng giao tiếp với DanaRS v1 của bạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "在配对过程中，你的 DanaRS v1 胰岛素泵会显示一个配对提示，而你的 iPhone 会弹出输入配对码的提示。在胰岛素泵上选择“确定”，然后在 iPhone 上输入该配对码。完成后，%1$@ 将准备好与 DanaRS v1 通讯。"
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         }
       }
@@ -7429,7 +10099,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
@@ -7439,7 +10115,7 @@
             "value" : "Durante il processo di accoppiamento, il DanaRS v1 mostrerà una richiesta di accoppiamento, mentre l'iPhone mostrerà una richiesta di codice di accoppiamento. Sulla pompa, selezionare OK e digitare il codice sull'iPhone. Dopodiché, Loop è pronto a comunicare con il DanaRS v1."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Under sammenkoblingsprosessen vil DanaRS v1 vise en sammenkoblingsmelding, mens iPhone vil vise en melding om en sammenkoblingskode. Velg OK på pumpen, og skriv inn koden på iPhone. Etter dette er Loop klar til å kommunisere med DanaRS v1"
@@ -7455,6 +10131,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Podczas parowania, DanaRS v1 wyświetli monit o parowanie, a iPhone wyświetli monit o podanie kodu parowania. Na pompie wybierz OK i wpisz kod na iPhonie. Następnie Loop będzie gotowy do komunikacji z DanaRS v1."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
         "pt_BR" : {
@@ -7487,9 +10169,21 @@
             "value" : "Eşleştirme işlemi sırasında DanaRS v1 cihazınız bir eşleştirme istemi gösterirken iPhone cihazınız bir eşleştirme kodu istemi gösterecektir. Pompanızda Tamam'ı seçin ve kodu iPhone'unuza yazın. Bundan sonra Loop, DanaRS v1 cihazınızla iletişim kurmaya hazırdır"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
@@ -7505,28 +10199,130 @@
       "comment" : "Subtext for danars v1",
       "extractionState" : "manual",
       "localizations" : {
-        "cs" : {
+        "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Během procesu párování se na displeji zařízení DanaRS v3 zobrazí výzva ke spárování, zatímco na displeji iPhonu se zobrazí výzva k zadání párovacího kódu. Na pumpě vyberte OK a zadejte kód na iPhonu. Poté je zařízení Loop připraveno ke komunikaci s vaším zařízením DanaRS v1."
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
-        "ja" : {
+        "da" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ペアリング中、DanaRS v3にはペアリングのプロンプトが表示され、iPhoneにはペアリングコードのプロンプトが表示されます。ポンプでOKを選択し、iPhoneにコードを入力します。その後、LoopはDanaRS v1と通信できます。"
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
-        "nb" : {
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Under sammenkoblingsprosessen vil DanaRS v3 vise en sammenkoblingsmelding, mens iPhone vil vise en melding om en sammenkoblingskode. Velg OK på pumpen, og skriv inn koden på iPhone. Etter dette er Loop klar til å kommunisere med DanaRS v1"
           }
         },
-        "ro" : {
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "În timpul procesului de împerechere, DanaRS v3 va afișa o solicitare de împerechere, în timp ce iPhone-ul va afișa o solicitare pentru un cod de împerechere. Pe pompă, selectați OK și tastați codul de pe iPhone. După aceea, Loop este gata să comunice cu DanaRS v1"
+            "value" : "Under parkopplingsprocessen kommer DanaRS v3 att visa en parkopplingsförfrågan medan din iPhone kommer att visa en fråga om en parkopplingskod. Välj OK på din pump och skriv in koden på din iPhone. Efter det är Loop redo att kommunicera med din DanaRS v1"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
         "zh-Hans" : {
@@ -7540,16 +10336,136 @@
     "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3" : {
       "comment" : "Subtext for danars v3 (1: appName)",
       "localizations" : {
-        "nb" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Under sammenkoblingsprosessen vil DanaRS v3 vise en sammenkoblingsmelding, mens iPhone vil vise en melding om to sammenkoblingskoder. Velg OK på pumpen, og skriv inn de to kodene på iPhone. Etter dette er %1$@ klar til å kommunisere med DanaRS v3"
+            "value" : "أثناء عملية الإقران، ستظهر رسالة تأكيد على جهاز DanaRS v3 الخاص بك، بينما سيظهر على جهاز iPhone الخاص بك مربع لإدخال رمزَي إقران. على المضخة، اضغط على \"موافق\"، ثم أدخل الرمزين في جهاز iPhone. بعد ذلك، يصبح %1$@ جاهزًا للتواصل مع جهاز DanaRS v3 الخاص بك"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tijdens het koppelingsproces toont je DanaRS v3 een koppelingsverzoek, terwijl je iPhone om twee koppelingscodes vraagt. Selecteer 'OK' op je pomp en voer beide codes in op je iPhone. Daarna is %1$@ klaar om te communiceren met je DanaRS v3"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Во время процесса сопряжения на вашей DanaRS v3 появится запрос на сопряжение, а на вашем iPhone отобразится запрос на ввод двух кодов сопряжения. На помпе выберите «ОК» и введите оба кода на вашем iPhone. После этого %1$@ будет готов к взаимодействию с вашей DanaRS v3"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Počas procesu párovania zobrazí tvoja DanaRS v3 výzvu na párovanie, zatiaľ čo tvoj iPhone zobrazí výzvu na zadanie dvoch párovacích kódov. Na pumpe zvoľ OK a zadaj oba kódy do svojho iPhonu. Potom bude %1$@ pripravený komunikovať s tvojou DanaRS v3"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Under parkopplingsprocessen kommer DanaRS v3 att visa en parkopplingsfråga medan din iPhone kommer att visa en fråga om två parkopplingskoder. Välj OK på din pump och skriv in de två koderna på din iPhone. Efter det är %1$@ redo att kommunicera med din DanaRS v3"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Під час процесу створення пари на вашому DanaRS v3 відображатиметься запит на створення пари, а на вашому iPhone – два коди сполучення. На помпі виберіть OK і введіть два коди на своєму iPhone. Після цього %1$@ готовий до зв’язку з DanaRS v3"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trong quá trình ghép đôi, DanaRS v3 của bạn sẽ hiển thị lời nhắc ghép đôi, trong khi iPhone của bạn sẽ hiển thị lời nhắc yêu cầu nhập hai mã ghép đôi. Trên bơm, hãy chọn OK và nhập hai mã đó trên iPhone của bạn. Sau đó, %1$@ đã sẵn sàng để giao tiếp với DanaRS v3 của bạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "在配对过程中，你的 DanaRS v3 胰岛素泵会显示一个配对提示，而你的 iPhone 会显示两个配对码的输入框。在胰岛素泵上选择“确定”，然后在 iPhone 上输入这两个配对码。完成后，%1$@ 将准备好与 DanaRS v3 通讯。"
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         }
       }
@@ -7562,12 +10478,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "أثناء عملية الاقتران، ستظهر لك مضخة DanaRS v3 مطالبة بالاقتران بينما سيظهر لك جهاز iPhone مطالبة برمزي اقتران. على المضخة الخاصة بك، حدد موافق واكتب الرمزين على جهاز iPhone الخاص بك. بعد ذلك، تصبح Loop جاهزة للتواصل مع جهاز DanaRS v3 الخاص بك"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Během procesu párování se na displeji zařízení DanaRS v3 zobrazí výzva ke spárování, zatímco na displeji iPhonu se zobrazí výzva k zadání dvou párovacích kódů. Na pumpě vyberte OK a zadejte dva kódy na iPhonu. Poté je zařízení Loop připraveno ke komunikaci s vaším zařízením DanaRS v3."
           }
         },
         "da" : {
@@ -7608,7 +10518,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3"
           }
         },
@@ -7618,13 +10534,7 @@
             "value" : "Durante il processo di accoppiamento, il DanaRS v3 mostrerà una richiesta di accoppiamento, mentre l'iPhone mostrerà una richiesta di due codici di accoppiamento. Sulla pompa, selezionare OK e digitare i due codici sull'iPhone. Dopodiché, Loop è pronto a comunicare con il DanaRS v3."
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ペアリング中、DanaRS v3にはペアリングのプロンプトが表示され、iPhoneには2つのペアリングコードを入力するプロンプトが表示されます。ポンプでOKを選択し、iPhoneに2つのコードを入力します。その後、LoopはDanaRS v3と通信できるようになります。"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Under sammenkoblingsprosessen vil DanaRS v3 vise en sammenkoblingsmelding, mens iPhone vil vise en melding om to sammenkoblingskoder. Velg OK på pumpen, og skriv inn de to kodene på iPhone. Etter dette er Loop klar til å kommunisere med DanaRS v3"
@@ -7642,16 +10552,16 @@
             "value" : "Podczas procesu parowania DanaRS v3 wyświetli monit o sparowanie, a iPhone wyświetli monit o dwa kody parowania. Na pompie wybierz OK i wpisz dwa kody na iPhonie. Następnie Loop jest gotowy do komunikacji z DanaRS v3"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Durante o processo de emparelhamento, o DanaRS v3 mostrará uma solicitação de emparelhamento, enquanto o iPhone mostrará uma solicitação de dois códigos de emparelhamento. Em sua bomba, selecione OK e digite os dois códigos em seu iPhone. Depois disso, o Loop estará pronto para se comunicar com o DanaRS v3"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "În timpul procesului de împerechere, DanaRS v3 va afișa o solicitare de împerechere, în timp ce iPhone-ul va afișa o solicitare pentru două coduri de împerechere. Pe pompă, selectați OK și tastați cele două coduri pe iPhone. După aceea, Loop este gata să comunice cu DanaRS v3"
           }
         },
         "ru" : {
@@ -7678,9 +10588,21 @@
             "value" : "Eşleştirme işlemi sırasında DanaRS v3 cihazınız bir eşleştirme istemi gösterirken iPhone'unuz iki eşleştirme kodu istemi gösterecektir. Pompanızda Tamam'ı seçin ve iPhone'unuza iki kodu yazın. Bundan sonra Loop, DanaRS v3 cihazınızla iletişim kurmaya hazırdır"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3"
+          }
+        },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3"
           }
         },
@@ -7698,37 +10620,31 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "خزان فارغ"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Prázdná nádrž"
+            "value" : "الخزان فارغ"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tøm reservoiret"
+            "value" : "Tomt reservoir"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Behälter entleeren"
+            "value" : "Reservoir leer"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Depósito vacío"
+            "value" : "Reservorio vacío"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tyhjä säiliö"
+            "value" : "Säiliö tyhjä"
           }
         },
         "fr" : {
@@ -7739,7 +10655,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Empty reservoir"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Empty reservoir"
           }
         },
@@ -7749,22 +10671,16 @@
             "value" : "Serbatoio vuoto"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "空のリザーバー"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Empty reservoir"
+            "value" : "Tomt reservoar"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Leeg reservoir"
+            "value" : "Reservoir leeg"
           }
         },
         "pl" : {
@@ -7773,22 +10689,22 @@
             "value" : "Pusty zbiornik"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Empty reservoir"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reservatório vazio"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rezervor gol"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Пустой резервуар"
+            "value" : "Резервуар пуст"
           }
         },
         "sk" : {
@@ -7800,7 +10716,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Töm behållaren"
+            "value" : "Poddfel; tom reservoar"
           }
         },
         "tr" : {
@@ -7809,16 +10725,28 @@
             "value" : "Boş rezervuar"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Порожній резервуар"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Hết insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Empty reservoir"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "空水库"
+            "value" : "胰岛素储量为零"
           }
         }
       }
@@ -7830,12 +10758,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "خطأ أثناء الاتصال بالجهاز"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chyba při připojování k zařízení"
           }
         },
         "da" : {
@@ -7870,7 +10792,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Error while connecting to device"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Error while connecting to device"
           }
         },
@@ -7880,15 +10808,9 @@
             "value" : "Errore durante la connessione al dispositivo"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "デバイス接続時のエラー"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Error while connecting to device"
           }
         },
@@ -7904,16 +10826,16 @@
             "value" : "Błąd podczas łączenia z urządzeniem"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erro ao se conectar ao dispositivo"
+            "state" : "new",
+            "value" : "Error while connecting to device"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare în timpul conectării la dispozitiv"
+            "state" : "new",
+            "value" : "Error while connecting to device"
           }
         },
         "ru" : {
@@ -7940,9 +10862,21 @@
             "value" : "Cihaza bağlanırken hata oluştu"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помилка під час підключення до пристрою"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Lỗi khi kết nối với thiết bị"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Error while connecting to device"
           }
         },
@@ -7956,6 +10890,132 @@
     },
     "Error while starting scanning for devices..." : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fel vid skanning efter enheter..."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Error while starting scanning for devices..."
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7973,16 +11033,10 @@
             "value" : "خطأ: فشل في إقران الجهاز"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "CHYBA: Nepodařilo se spárovat zařízení"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "FEJL: Kunne ikke parre enheden"
+            "value" : "FEJL: Mislykkedes at parre enhed"
           }
         },
         "de" : {
@@ -8011,7 +11065,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "ERROR: Failed to pair device"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "ERROR: Failed to pair device"
           }
         },
@@ -8021,16 +11081,10 @@
             "value" : "ERRORE: Impossibile accoppiare il dispositivo"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERROR：デバイスのペアリングに失敗しました"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "FEIL: Kunne ikke koble sammen enheten"
+            "state" : "new",
+            "value" : "ERROR: Failed to pair device"
           }
         },
         "nl" : {
@@ -8045,16 +11099,16 @@
             "value" : "BŁĄD: Nie udało się sparować urządzenia"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERRO: Falha ao emparelhar o dispositivo"
+            "state" : "new",
+            "value" : "ERROR: Failed to pair device"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ERROR: Eșec la împerecherea dispozitivului"
+            "state" : "new",
+            "value" : "ERROR: Failed to pair device"
           }
         },
         "ru" : {
@@ -8081,9 +11135,21 @@
             "value" : "HATA: Cihaz eşleştirilemedi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ПОМИЛКА: не вдалося підключити пристрій"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "LỖI: Không ghép nối được thiết bị"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "ERROR: Failed to pair device"
           }
         },
@@ -8102,12 +11168,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "فشل في ضبط القاعدة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nepodařilo se upravit bazální"
           }
         },
         "da" : {
@@ -8142,7 +11202,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Failed to adjust basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to adjust basal"
           }
         },
@@ -8152,15 +11218,9 @@
             "value" : "Mancata regolazione della basale"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "基礎体温の調整に失敗"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Failed to adjust basal"
           }
         },
@@ -8176,28 +11236,28 @@
             "value" : "Nie udało się dostosować podstawowej dawki"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha no ajuste basal"
+            "state" : "new",
+            "value" : "Failed to adjust basal"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu a reușit să ajusteze bazal"
+            "state" : "new",
+            "value" : "Failed to adjust basal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Не удалось скорректировать базальный уровень"
+            "value" : "Не удалось установить базальную скорость"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nepodarilo sa upraviť bazálnu"
+            "value" : "Nepodarilo sa upraviť bazál"
           }
         },
         "sv" : {
@@ -8212,9 +11272,21 @@
             "value" : "Bazal ayarlama yapılamadı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося відкоригувати Базал"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Không thể điều chỉnh liều basal"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to adjust basal"
           }
         },
@@ -8233,12 +11305,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "فشل في ضبط وقت المضخة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nepodařilo se nastavit čas čerpadla"
           }
         },
         "da" : {
@@ -8273,7 +11339,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Failed to adjust pump time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to adjust pump time"
           }
         },
@@ -8283,15 +11355,9 @@
             "value" : "Mancata regolazione del tempo di pompaggio"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプ時間の調整に失敗"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Failed to adjust pump time"
           }
         },
@@ -8307,28 +11373,28 @@
             "value" : "Nie udało się ustawić czasu pompy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha no ajuste do tempo da bomba"
+            "state" : "new",
+            "value" : "Failed to adjust pump time"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu a reușit să regleze timpul de pompare"
+            "state" : "new",
+            "value" : "Failed to adjust pump time"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Не удалось отрегулировать время работы насоса"
+            "value" : "Не удалось установить время на помпе"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nepodarilo sa nastaviť čas čerpadla"
+            "value" : "Nepodarilo sa nastaviť čas pumpy"
           }
         },
         "sv" : {
@@ -8343,9 +11409,21 @@
             "value" : "Pompa süresi ayarlanamadı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося налаштувати час помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Không điều chỉnh được thời gian bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to adjust pump time"
           }
         },
@@ -8364,12 +11442,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "فشل في ضبط التعليق"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nepodařilo se nastavit odpružení"
           }
         },
         "da" : {
@@ -8404,7 +11476,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Failed to adjust suspension"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to adjust suspension"
           }
         },
@@ -8414,15 +11492,9 @@
             "value" : "Mancata regolazione della sospensione"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "サスペンションの調整に失敗"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Failed to adjust suspension"
           }
         },
@@ -8438,22 +11510,22 @@
             "value" : "Nie udało się wyregulować zawieszenia"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha no ajuste da suspensão"
+            "state" : "new",
+            "value" : "Failed to adjust suspension"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu a reușit să regleze suspensia"
+            "state" : "new",
+            "value" : "Failed to adjust suspension"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Не удалось отрегулировать подвеску"
+            "value" : "Не удалось приостановить подачу инсулина"
           }
         },
         "sk" : {
@@ -8474,9 +11546,21 @@
             "value" : "Süspansiyon ayarlanamadı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося налаштувати призупинення"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Không thể điều chỉnh bởi hệ thống treo"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to adjust suspension"
           }
         },
@@ -8496,12 +11580,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "فشل في ضبط درجة الحرارة القاعدية"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nepodařilo se nastavit bazální teplotu"
           }
         },
         "da" : {
@@ -8542,7 +11620,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Failed to adjust temp basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to adjust temp basal"
           }
         },
@@ -8552,15 +11636,9 @@
             "value" : "Impossibile regolare la temperatura basale"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "基礎体温の調整に失敗"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Failed to adjust temp basal"
           }
         },
@@ -8576,28 +11654,28 @@
             "value" : "Nie udało się dostosować temperatury podstawowej"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha no ajuste da temperatura basal"
+            "state" : "new",
+            "value" : "Failed to adjust temp basal"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu a reușit să ajusteze temp basal"
+            "state" : "new",
+            "value" : "Failed to adjust temp basal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Не удалось отрегулировать базальную температуру"
+            "value" : "Не удалось установить временную базальную скорость"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nepodarilo sa nastaviť bazálnu teplotu"
+            "value" : "Nepodarilo sa nastaviť dočasný bazál"
           }
         },
         "sv" : {
@@ -8612,9 +11690,21 @@
             "value" : "Bazal sıcaklık ayarlanamadı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося налаштувати темп Базалу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Không thể điều chỉnh liều temp basal"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to adjust temp basal"
           }
         },
@@ -8635,16 +11725,10 @@
             "value" : "فشل في إنشاء برنامج دانا بازل"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nepodařilo se vygenerovat základní program Dana"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kunne ikke generere Dana basalprogram"
+            "value" : "Kunne ikke generere Dana-basalprogram"
           }
         },
         "de" : {
@@ -8673,7 +11757,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Failed to generate Dana basal program"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to generate Dana basal program"
           }
         },
@@ -8683,15 +11773,9 @@
             "value" : "Impossibile generare il programma Dana basal"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダナ・ベーサル・プログラムの生成に失敗"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Failed to generate Dana basal program"
           }
         },
@@ -8707,28 +11791,28 @@
             "value" : "Nie udało się wygenerować programu bazowego Dana"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao gerar o programa básico da Dana"
+            "state" : "new",
+            "value" : "Failed to generate Dana basal program"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu a reușit să genereze programul de bază Dana"
+            "state" : "new",
+            "value" : "Failed to generate Dana basal program"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Не удалось сгенерировать программу Dana basal"
+            "value" : "Не удалось сгенерировать базальную программу Dana"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nepodarilo sa vygenerovať základný program Dana"
+            "value" : "Nepodarilo sa vygenerovať nastavenia bazálu pre Dana"
           }
         },
         "sv" : {
@@ -8743,9 +11827,21 @@
             "value" : "Dana bazal programı oluşturulamadı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося створити  програму Базалу Dana"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Không tạo được liều basal Dana"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to generate Dana basal program"
           }
         },
@@ -8765,12 +11861,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "فشل في إجراء اتصال"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nepodařilo se navázat spojení"
           }
         },
         "da" : {
@@ -8811,7 +11901,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Failed to make a connection"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to make a connection"
           }
         },
@@ -8821,15 +11917,9 @@
             "value" : "Impossibile stabilire una connessione"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "接続に失敗しました"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Failed to make a connection"
           }
         },
@@ -8845,16 +11935,16 @@
             "value" : "Nie udało się nawiązać połączenia"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao fazer uma conexão"
+            "state" : "new",
+            "value" : "Failed to make a connection"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "A eșuat realizarea unei conexiuni"
+            "state" : "new",
+            "value" : "Failed to make a connection"
           }
         },
         "ru" : {
@@ -8881,9 +11971,21 @@
             "value" : "Bağlantı kurulamadı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося встановити з'єднання"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Không thể kết nối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to make a connection"
           }
         },
@@ -8898,6 +12000,132 @@
     "Failed to pair to " : {
       "comment" : "Dana-i failed to pair p1",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunde inte parkoppla med "
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to pair to "
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8918,7 +12146,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kanylen blev ikke primet. Prøv venligst igen senere"
+            "value" : "Mislykkedes at spæde kanyle. Forsøg igen senere"
           }
         },
         "de" : {
@@ -8947,7 +12175,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Failed to prime the cannula. Please try again later"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to prime the cannula. Please try again later"
           }
         },
@@ -8957,7 +12191,7 @@
             "value" : "Non è stato possibile adescare la cannula. Riprovare più tardi"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mislyktes å kontrollere kanylen. Vennligst prøv igjen senere"
@@ -8975,10 +12209,16 @@
             "value" : "Nie udało się zalać kaniuli. Spróbuj ponownie później"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to prime the cannula. Please try again later"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao preparar a cânula. Tente novamente mais tarde"
+            "state" : "new",
+            "value" : "Failed to prime the cannula. Please try again later"
           }
         },
         "ru" : {
@@ -9005,9 +12245,21 @@
             "value" : "Kanül prime edilemedi. Lütfen daha sonra tekrar deneyin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося заповнити Канюлю. Спробуйте пізніше"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Failed to prime the cannula. Please try again later"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to prime the cannula. Please try again later"
           }
         },
@@ -9031,7 +12283,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Det lykkedes ikke at prime slangen. Prøv venligst igen senere"
+            "value" : "Mislykkedes at spæde slange. Forsøg igen senere"
           }
         },
         "de" : {
@@ -9060,7 +12312,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Failed to prime the tube. Please try again later"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to prime the tube. Please try again later"
           }
         },
@@ -9070,7 +12328,7 @@
             "value" : "Non è stato possibile adescare il tubo. Riprovare più tardi"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kan ikke kontrollere turen. Prøv igjen senere"
@@ -9088,10 +12346,16 @@
             "value" : "Nie udało się zalać przewodu. Spróbuj ponownie później"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to prime the tube. Please try again later"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao preparar o tubo. Tente novamente mais tarde"
+            "state" : "new",
+            "value" : "Failed to prime the tube. Please try again later"
           }
         },
         "ru" : {
@@ -9118,9 +12382,21 @@
             "value" : "Tüp doldurulamadı. Lütfen daha sonra tekrar deneyin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося заправити трубку. Спробуйте пізніше"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Failed to prime the cannula. Please try again later"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to prime the tube. Please try again later"
           }
         },
@@ -9144,7 +12420,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Det lykkedes ikke at indstille reservoirmængden. Synkroniser pumpedata igen, og prøv igen."
+            "value" : "Mislykkedes at indstille reservoirmængde. Gensynk pumpedata, og forsøg igen"
           }
         },
         "de" : {
@@ -9173,7 +12449,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Failed to set reservoir amount. Re-sync pump data and try again please"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to set reservoir amount. Re-sync pump data and try again please"
           }
         },
@@ -9183,7 +12465,7 @@
             "value" : "Impossibile impostare la quantità di serbatoio. Risincronizzare i dati della pompa e riprovare."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kunne ikke angi reservoarmengde. Resynkroniser pumpens data og prøv igjen"
@@ -9201,16 +12483,22 @@
             "value" : "Nie udało się ustawić ilości w zbiorniku. Ponownie zsynchronizuj dane pompy i spróbuj ponownie."
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Failed to set reservoir amount. Re-sync pump data and try again please"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falha ao definir a quantidade do reservatório. Re-sincronize os dados da bomba e tente novamente"
+            "state" : "new",
+            "value" : "Failed to set reservoir amount. Re-sync pump data and try again please"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Не удалось установить объем резервуара. Пересинхронизируйте данные насоса и повторите попытку, пожалуйста"
+            "value" : "Не удалось установить объем инсулина в резервуаре. Пересинхронизируйте данные помпы и повторите попытку"
           }
         },
         "sk" : {
@@ -9231,9 +12519,21 @@
             "value" : "Rezervuar miktarı ayarlanamadı. Pompa verilerini yeniden senkronize edin ve tekrar deneyin lütfen"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Не вдалося встановити обсяг Резервуара. Повторно синхронізуйте дані насоса та повторіть спробу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Không thể thiết lập reservoir. Đồng bộ lại dữ liệu bơm và vui lòng thử lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Failed to set reservoir amount. Re-sync pump data and try again please"
           }
         },
@@ -9252,12 +12552,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "أدخل كلمة المرور"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vyplňte heslo"
           }
         },
         "da" : {
@@ -9292,7 +12586,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Fill in password"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Fill in password"
           }
         },
@@ -9302,15 +12602,9 @@
             "value" : "Inserire la password"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "パスワードを入力"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Fill in password"
           }
         },
@@ -9326,16 +12620,16 @@
             "value" : "Wpisz hasło"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Preencha a senha"
+            "state" : "new",
+            "value" : "Fill in password"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Introduceți parola"
+            "state" : "new",
+            "value" : "Fill in password"
           }
         },
         "ru" : {
@@ -9362,9 +12656,21 @@
             "value" : "Şifreyi girin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пароль DanaRS v1"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Điền mật khẩu"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Fill in password"
           }
         },
@@ -9383,12 +12689,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الإنهاء"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dokončení"
           }
         },
         "da" : {
@@ -9423,7 +12723,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Finish"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Finish"
           }
         },
@@ -9433,15 +12739,9 @@
             "value" : "Finitura"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "終了"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Finish"
           }
         },
@@ -9457,28 +12757,28 @@
             "value" : "Zakończenie"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Acabamento"
+            "state" : "new",
+            "value" : "Finish"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Terminare"
+            "state" : "new",
+            "value" : "Finish"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Отделка"
+            "value" : "Завершить"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dokončenie"
+            "value" : "Dokončiť"
           }
         },
         "sv" : {
@@ -9493,9 +12793,21 @@
             "value" : "Bitiş"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Готово"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Hoàn thành"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Finish"
           }
         },
@@ -9514,12 +12826,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إصدار البرنامج الثابت"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Verze firmwaru"
           }
         },
         "da" : {
@@ -9554,7 +12860,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Firmware version"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Firmware version"
           }
         },
@@ -9564,15 +12876,9 @@
             "value" : "Versione del firmware"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ファームウェアバージョン"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Firmware version"
           }
         },
@@ -9588,16 +12894,16 @@
             "value" : "Wersja oprogramowania sprzętowego"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versão do firmware"
+            "state" : "new",
+            "value" : "Firmware version"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Versiunea firmware"
+            "state" : "new",
+            "value" : "Firmware version"
           }
         },
         "ru" : {
@@ -9624,9 +12930,21 @@
             "value" : "Ürün yazılımı sürümü"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Версія прошивки"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Phiên bản phần mềm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Firmware version"
           }
         },
@@ -9647,16 +12965,10 @@
             "value" : "وجدت مضخات Dana-i/RS"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nalezená čerpadla Dana-i/RS"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fandt Dana-i/RS-pumper"
+            "value" : "Dana-i/RS-pumper fundet"
           }
         },
         "de" : {
@@ -9685,7 +12997,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Found Dana-i/RS pumps"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Found Dana-i/RS pumps"
           }
         },
@@ -9695,15 +13013,9 @@
             "value" : "Trovate le pompe Dana-i/RS"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dana-i/RSポンプを発見"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Found Dana-i/RS pumps"
           }
         },
@@ -9719,28 +13031,28 @@
             "value" : "Znaleziono pompy Dana-i/RS"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bombas Dana-i/RS encontradas"
+            "state" : "new",
+            "value" : "Found Dana-i/RS pumps"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pompe Dana-i/RS găsite"
+            "state" : "new",
+            "value" : "Found Dana-i/RS pumps"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Найдены насосы Dana-i/RS"
+            "value" : "Найдены помпы Dana-i/RS"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nájdené čerpadlá Dana-i/RS"
+            "value" : "Nájdené pumpy Dana-i/RS"
           }
         },
         "sv" : {
@@ -9755,9 +13067,21 @@
             "value" : "Dana-i/RS pompaları bulundu"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Знайшлися помпи Dana-i/RS"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã tìm thấy Dana-i"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Found Dana-i/RS pumps"
           }
         },
@@ -9776,12 +13100,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "طراز الأجهزة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hardwarový model"
           }
         },
         "da" : {
@@ -9816,7 +13134,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Hardware model"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Hardware model"
           }
         },
@@ -9826,15 +13150,9 @@
             "value" : "Modello hardware"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ハードウェア・モデル"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Hardware model"
           }
         },
@@ -9850,22 +13168,22 @@
             "value" : "Model sprzętowy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Modelo de hardware"
+            "state" : "new",
+            "value" : "Hardware model"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Model hardware"
+            "state" : "new",
+            "value" : "Hardware model"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Аппаратная модель"
+            "value" : "Модель устройства"
           }
         },
         "sk" : {
@@ -9886,9 +13204,21 @@
             "value" : "Donanım modeli"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Модель обладнання"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Mô hình phần cứng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Hardware model"
           }
         },
@@ -9907,12 +13237,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الأنسولين\nمعلق"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Inzulín\nPozastaveno"
           }
         },
         "da" : {
@@ -9947,7 +13271,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Insulin\nSuspended"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin\nSuspended"
           }
         },
@@ -9957,13 +13287,7 @@
             "value" : "Insulina \nSospesa"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "インスリン\n停止"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulin\n Suspendert"
@@ -9981,16 +13305,16 @@
             "value" : "Podawanie\nzawieszone"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin\nSuspended"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulina\nSuspenso"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulină\nSuspendată"
           }
         },
         "ru" : {
@@ -10017,9 +13341,21 @@
             "value" : "İnsülin\nAskıya Alındı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin\nSuspended"
+          }
+        },
         "vi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Insulin\nSuspended"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin\nSuspended"
           }
         },
@@ -10040,16 +13376,10 @@
             "value" : "توصيل الأنسولين"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dodávka inzulínu"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Levering af insulin"
+            "value" : "Insulintilførsel"
           }
         },
         "de" : {
@@ -10066,38 +13396,38 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insuliinin toimitus"
+            "state" : "new",
+            "value" : "Insulin Delivery"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Administration d'insuline"
+            "value" : "Administration de l'insuline"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Insulin Delivery"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin Delivery"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Consegna dell'insulina"
+            "value" : "Insulina Somministrata"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "インスリンデリバリー"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulin Delivery"
+            "value" : "Insulintilførsel"
           }
         },
         "nl" : {
@@ -10108,32 +13438,32 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dostarczanie insuliny"
+            "state" : "new",
+            "value" : "Insulin Delivery"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Delivery"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Administração de insulina"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Administrarea insulinei"
+            "state" : "new",
+            "value" : "Insulin Delivery"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Доставка инсулина"
+            "value" : "Подача инсулина"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dodávka inzulínu"
+            "value" : "Podávanie inzulínu"
           }
         },
         "sv" : {
@@ -10145,19 +13475,31 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İnsülin Dağıtımı"
+            "value" : "İnsülin İletimi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подання Інсуліну"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Khối lượng tiêm insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin Delivery"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "胰岛素输送"
+            "value" : "胰岛素输注"
           }
         }
       }
@@ -10171,16 +13513,10 @@
             "value" : "الأنسولين المتبقي"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zbývající inzulín"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Resterende insulin"
+            "value" : "Resterende Insulin"
           }
         },
         "de" : {
@@ -10197,8 +13533,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jäljellä oleva insuliini"
+            "state" : "new",
+            "value" : "Insulin Remaining"
           }
         },
         "fr" : {
@@ -10209,26 +13545,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Insulin Remaining"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin Remaining"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulina rimanente"
+            "value" : "Insulina Rimanente"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "インスリン残量"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulin Remaining"
+            "value" : "Insulin i pod"
           }
         },
         "nl" : {
@@ -10239,26 +13575,26 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pozostała insulina"
+            "state" : "new",
+            "value" : "Insulin Remaining"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Remaining"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulina restante"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulină rămasă"
+            "state" : "new",
+            "value" : "Insulin Remaining"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Остаток инсулина"
+            "value" : "Осталось инсулина"
           }
         },
         "sk" : {
@@ -10270,7 +13606,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kvarvarande insulin"
+            "value" : "Insulin kvar"
           }
         },
         "tr" : {
@@ -10279,16 +13615,28 @@
             "value" : "Kalan İnsülin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Залишок Інсуліну"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Insulin còn lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin Remaining"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "胰岛素剩余量"
+            "value" : "胰岛素余量"
           }
         }
       }
@@ -10298,14 +13646,8 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "تعليق الأنسولين"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pozastavení podávání inzulínu"
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         },
         "da" : {
@@ -10317,109 +13659,121 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin suspendiert"
+            "value" : "Insulin ausgesetzt"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulina Suspendida"
+            "value" : "Insulina suspendida"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insuliini keskeytetty"
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Suspension de l'insuline"
+            "value" : "Insuline suspendue"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin Suspended"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulina sospesa"
+            "value" : "Insulina Sospesa"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "インスリン中断"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulin Suspended"
+            "value" : "Insulintilførsel pauset"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insuline Opgeschort"
+            "value" : "Insuline tijdelijk uitgeschakeld"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulina zawieszona"
+            "state" : "new",
+            "value" : "Insulin Suspended"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulina suspensa"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulină suspendată"
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Инсулин приостановлен"
+            "value" : "Подача приостановлена"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Inzulín pozastavený"
+            "value" : "Inzulín Suspendovaný"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin suspenderat"
+            "value" : "Pump pausad"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İnsülin Askıya Alındı"
+            "value" : "İnsülin Durduldu"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подання Припинено"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã tạm dừng cấp liều Insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin Suspended"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "胰岛素停用"
+            "state" : "new",
+            "value" : "Insulin Suspended"
           }
         }
       }
@@ -10430,19 +13784,13 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "نوع الأنسولين"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Typ inzulínu"
+            "value" : "نوع الإنسولين"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin-type"
+            "value" : "Insulintype"
           }
         },
         "de" : {
@@ -10454,67 +13802,67 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tipo de insulina"
+            "value" : "Tipo de Insulina"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insuliinityyppi"
+            "state" : "new",
+            "value" : "Insulin Type"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Type d'insuline"
+            "value" : "Type d'Insuline"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Insulin Type"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin Type"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tipo di insulina"
+            "value" : "Tipo di Insulina"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "インスリンの種類"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Insulin Type"
+            "value" : "Insulintype"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Type insuline"
+            "value" : "Insulinesoort"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Typ insuliny"
+            "state" : "new",
+            "value" : "Insulin Type"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Insulin Type"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tipo de insulina"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipul de insulină"
+            "value" : "Tipo de Insulina"
           }
         },
         "ru" : {
@@ -10526,13 +13874,13 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Typ inzulínu"
+            "value" : "Typ Inzulínu"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin typ"
+            "value" : "Typ av insulin"
           }
         },
         "tr" : {
@@ -10541,9 +13889,21 @@
             "value" : "İnsülin Tipi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тип Інсуліну"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Loại Insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Insulin Type"
           }
         },
@@ -10564,16 +13924,10 @@
             "value" : "آخر مزامنة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poslední synchronizace"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sidste synkronisering"
+            "value" : "Senete synk"
           }
         },
         "de" : {
@@ -10602,7 +13956,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Last sync"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Last sync"
           }
         },
@@ -10612,15 +13972,9 @@
             "value" : "Ultima sincronizzazione"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "最後の同期"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Last sync"
           }
         },
@@ -10636,16 +13990,16 @@
             "value" : "Ostatnia synchronizacja"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Última sincronização"
+            "state" : "new",
+            "value" : "Last sync"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ultima sincronizare"
+            "state" : "new",
+            "value" : "Last sync"
           }
         },
         "ru" : {
@@ -10672,9 +14026,21 @@
             "value" : "Son senkronizasyon"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Остання синхронізація"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Lần đồng bộ gần đây nhất"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Last sync"
           }
         },
@@ -10695,16 +14061,10 @@
             "value" : "شاشة LCD في الوقت المحدد"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lcd na čas"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lcd på tid"
+            "value" : "LCD på tidspunktet"
           }
         },
         "de" : {
@@ -10727,13 +14087,19 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lcd on time"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Lcd on time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Lcd on time"
           }
         },
@@ -10743,22 +14109,16 @@
             "value" : "Tempo di accensione dell'Lcd"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "液晶点灯時間"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Lcd on time"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lcd aan tijd"
+            "value" : "Lcd op tijd"
           }
         },
         "pl" : {
@@ -10767,28 +14127,28 @@
             "value" : "Czas włączenia wyświetlacza LCD"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tempo de funcionamento do Lcd"
+            "state" : "new",
+            "value" : "Lcd on time"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lcd pe timp"
+            "state" : "new",
+            "value" : "Lcd on time"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Время включения ЖК-дисплея"
+            "value" : "Время отображения экрана"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lcd na čas"
+            "value" : "Čas zapnutia displeja"
           }
         },
         "sv" : {
@@ -10803,9 +14163,21 @@
             "value" : "Lcd açık kalma süresi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Час увімкнення РК-дисплея"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Màn hình Lcd time"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Lcd on time"
           }
         },
@@ -10824,19 +14196,13 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "التحميل"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "nakládání"
+            "value" : "جاري التحميل"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indlæsning"
+            "value" : "indlæser"
           }
         },
         "de" : {
@@ -10871,26 +14237,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "loading"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "loading"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Caricamento..."
+            "value" : "caricamento"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ローディング"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laster"
+            "state" : "new",
+            "value" : "loading"
           }
         },
         "nl" : {
@@ -10905,16 +14271,16 @@
             "value" : "ładowanie"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "carregamento"
+            "state" : "new",
+            "value" : "loading"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "încărcare"
+            "state" : "new",
+            "value" : "loading"
           }
         },
         "ru" : {
@@ -10926,7 +14292,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "nakladanie"
+            "value" : "načítanie"
           }
         },
         "sv" : {
@@ -10941,16 +14307,28 @@
             "value" : "yükleme"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "завантаження"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "đang tải"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "loading"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "加载中"
+            "value" : "装载量"
           }
         }
       }
@@ -10965,16 +14343,10 @@
             "value" : "التحميل"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Načítání"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indlæsning"
+            "value" : "Indlæser"
           }
         },
         "de" : {
@@ -11009,7 +14381,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Loading"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Loading"
           }
         },
@@ -11019,16 +14397,10 @@
             "value" : "Caricamento"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ローディング"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Laster"
+            "state" : "new",
+            "value" : "Loading"
           }
         },
         "nl" : {
@@ -11043,16 +14415,16 @@
             "value" : "Ładowanie"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Carregamento"
+            "state" : "new",
+            "value" : "Loading"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Încărcare"
+            "state" : "new",
+            "value" : "Loading"
           }
         },
         "ru" : {
@@ -11079,9 +14451,21 @@
             "value" : "Yükleniyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Завантаження"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Loading"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Loading"
           }
         },
@@ -11100,12 +14484,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "انخفاض بطارية المضخة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vybitá baterie čerpadla"
           }
         },
         "da" : {
@@ -11140,7 +14518,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Low pump battery"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Low pump battery"
           }
         },
@@ -11150,16 +14534,10 @@
             "value" : "Batteria della pompa scarica"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプ電池残量低下"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lavt batteri i pumpen"
+            "state" : "new",
+            "value" : "Low pump battery"
           }
         },
         "nl" : {
@@ -11174,22 +14552,22 @@
             "value" : "Rozładowana bateria pompy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bateria da bomba fraca"
+            "state" : "new",
+            "value" : "Low pump battery"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baterie slabă a pompei"
+            "state" : "new",
+            "value" : "Low pump battery"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Разряженная батарея насоса"
+            "value" : "Низкий заряд батареи помпы"
           }
         },
         "sk" : {
@@ -11210,9 +14588,21 @@
             "value" : "Düşük pompa pili"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Розряджений акумулятор Помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Pin của bơm yếu"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Low pump battery"
           }
         },
@@ -11233,16 +14623,10 @@
             "value" : "تذكير بانخفاض مستوى الخزان"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Připomenutí nízké hladiny v nádrži"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Påmindelse om lav reservoirbeholdning"
+            "value" : "Lavt reservoir-påmindelse"
           }
         },
         "de" : {
@@ -11271,7 +14655,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Low reservoir reminder"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Low reservoir reminder"
           }
         },
@@ -11281,16 +14671,10 @@
             "value" : "Segnalazione del serbatoio basso"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "リザーバー残量警告"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Påminnelse om lavt reservoar"
+            "state" : "new",
+            "value" : "Low reservoir reminder"
           }
         },
         "nl" : {
@@ -11305,28 +14689,28 @@
             "value" : "Przypomnienie o niskim stanie zbiornika"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lembrete de reservatório baixo"
+            "state" : "new",
+            "value" : "Low reservoir reminder"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Memento rezervor scăzut"
+            "state" : "new",
+            "value" : "Low reservoir reminder"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Напоминание о низком уровне воды в резервуаре"
+            "value" : "Уведомление о низком уровне инсулина в резервуаре"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pripomienka nízkej nádrže"
+            "value" : "Pripomienka nízkej hladiny"
           }
         },
         "sv" : {
@@ -11341,9 +14725,21 @@
             "value" : "Düşük rezervuar hatırlatıcısı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нагадування про низький рівень Резервуару"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Báo nhắc gần hết thuốc"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Low reservoir reminder"
           }
         },
@@ -11364,16 +14760,10 @@
             "value" : "مزامنة وقت المضخة يدوياً"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ruční synchronizace času čerpadla"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synkroniser pumpetiden manuelt"
+            "value" : "Synk pumpetid manuelt"
           }
         },
         "de" : {
@@ -11402,7 +14792,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Manually sync Pump time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Manually sync Pump time"
           }
         },
@@ -11412,16 +14808,10 @@
             "value" : "Sincronizzazione manuale dell'ora della pompa"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプ時間を手動で同期"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synkroniser pumpetiden manuelt"
+            "state" : "new",
+            "value" : "Manually sync Pump time"
           }
         },
         "nl" : {
@@ -11436,28 +14826,28 @@
             "value" : "Ręczna synchronizacja czasu pompy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronização manual do tempo da bomba"
+            "state" : "new",
+            "value" : "Manually sync Pump time"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizarea manuală a timpului pompei"
+            "state" : "new",
+            "value" : "Manually sync Pump time"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ручная синхронизация времени работы насоса"
+            "value" : "Ручная синхронизация времени на помпе"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ručná synchronizácia času čerpadla"
+            "value" : "Zosynchronizovať čas pumpy"
           }
         },
         "sv" : {
@@ -11472,9 +14862,21 @@
             "value" : "Pompa zamanını manuel olarak senkronize edin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ручна синхронізація часу Помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đồng bộ thời gian bơm thủ công"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Manually sync Pump time"
           }
         },
@@ -11495,16 +14897,10 @@
             "value" : "فحص جلوكوز الدم الفائت"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zmeškaná kontrola glykémie"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Udeblevet blodsukkermåling"
+            "value" : "Missede blodsukkermåling"
           }
         },
         "de" : {
@@ -11533,7 +14929,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Missed Blood glucose check"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Missed Blood glucose check"
           }
         },
@@ -11543,16 +14945,10 @@
             "value" : "Mancato controllo della glicemia"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "血糖値チェックの見落とし"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mistet blodsukkermåling"
+            "state" : "new",
+            "value" : "Missed Blood glucose check"
           }
         },
         "nl" : {
@@ -11567,22 +14963,22 @@
             "value" : "Pominięta kontrola stężenia glukozy we krwi"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Falta de controle de glicose no sangue"
+            "state" : "new",
+            "value" : "Missed Blood glucose check"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lipsa controlului glicemiei"
+            "state" : "new",
+            "value" : "Missed Blood glucose check"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Пропущенный контроль уровня глюкозы в крови"
+            "value" : "Пропущен контроль уровня глюкозы в крови"
           }
         },
         "sk" : {
@@ -11603,9 +14999,21 @@
             "value" : "Kaçırılan Kan şekeri kontrolü"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пропущена перевірка рівня глюкози в крові"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Không thấy kiểm tra đường huyết"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Missed Blood glucose check"
           }
         },
@@ -11626,16 +15034,10 @@
             "value" : "مزامنة وقت الضخ ليلاً"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Noční synchronizace času čerpadla"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Natlig synkronisering af pumpetid"
+            "value" : "Natlig synk af pumpetid"
           }
         },
         "de" : {
@@ -11664,7 +15066,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Nightly pump time sync"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Nightly pump time sync"
           }
         },
@@ -11674,16 +15082,10 @@
             "value" : "Sincronizzazione notturna del tempo di pompaggio"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "夜間ポンプ時刻同期"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synkronisering av pumpetid om natten"
+            "state" : "new",
+            "value" : "Nightly pump time sync"
           }
         },
         "nl" : {
@@ -11698,28 +15100,28 @@
             "value" : "Nocna synchronizacja czasu pompowania"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronização noturna do tempo da bomba"
+            "state" : "new",
+            "value" : "Nightly pump time sync"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizarea nocturnă a timpului de pompare"
+            "state" : "new",
+            "value" : "Nightly pump time sync"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ночная синхронизация времени работы насоса"
+            "value" : "Ночная синхронизация времени на помпе"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nočná synchronizácia času čerpadla"
+            "value" : "Nočná synchronizácia času pumpy"
           }
         },
         "sv" : {
@@ -11734,9 +15136,21 @@
             "value" : "Gece pompa zamanı senkronizasyonu"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нічна синхронізація часу Помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Nightly pump time sync"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Nightly pump time sync"
           }
         },
@@ -11750,16 +15164,136 @@
     },
     "No" : {
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "لا"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nej"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nein"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ei"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Non"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nem"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nei"
           }
         },
-        "zh-Hans" : {
+        "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "不"
+            "value" : "Nee"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nie"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nej"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ні"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Không"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No"
           }
         }
       }
@@ -11770,13 +15304,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "لا أنسولين"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Žádný inzulín"
+            "value" : "لا يوجد إنسولين"
           }
         },
         "da" : {
@@ -11799,8 +15327,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ei insuliinia"
+            "state" : "new",
+            "value" : "No Insulin"
           }
         },
         "fr" : {
@@ -11811,26 +15339,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "No Insulin"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "No Insulin"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulina esaurita"
+            "value" : "Nessuna Insulina"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "インスリンなし"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ingen insulin"
+            "value" : "Tom for insulin"
           }
         },
         "nl" : {
@@ -11841,20 +15369,20 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brak insuliny"
+            "state" : "new",
+            "value" : "No Insulin"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No Insulin"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sem insulina"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fără insulină"
+            "state" : "new",
+            "value" : "No Insulin"
           }
         },
         "ru" : {
@@ -11878,19 +15406,31 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İnsülin yok"
+            "value" : "İnsülin Yok"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нема Інсуліну"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Hết Insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "No Insulin"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "无胰岛素"
+            "state" : "new",
+            "value" : "No Insulin"
           }
         }
       }
@@ -11904,16 +15444,10 @@
             "value" : "لا، فقط افصل الاتصال"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ne, jen se odpojte"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nej, bare afbryd forbindelsen"
+            "value" : "Nej, bare frakobl"
           }
         },
         "de" : {
@@ -11942,7 +15476,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "No, just disconnect"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "No, just disconnect"
           }
         },
@@ -11952,16 +15492,10 @@
             "value" : "No, basta disconnettersi"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "いいえ、切断するだけです"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nei, bare koble fra"
+            "state" : "new",
+            "value" : "No, just disconnect"
           }
         },
         "nl" : {
@@ -11976,22 +15510,22 @@
             "value" : "Nie, po prostu odłącz"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não, apenas desconecte"
+            "state" : "new",
+            "value" : "No, just disconnect"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu, doar deconectați"
+            "state" : "new",
+            "value" : "No, just disconnect"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Нет, просто отсоедините"
+            "value" : "Нет, просто отсоединить"
           }
         },
         "sk" : {
@@ -12012,9 +15546,21 @@
             "value" : "Hayır, sadece bağlantıyı kes"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ні, просто відключити"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Không, chỉ cần ngắt kết nối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "No, just disconnect"
           }
         },
@@ -12033,12 +15579,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "لا، احتفظ بها كما هي"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ne, ponechat ve stávajícím stavu"
           }
         },
         "da" : {
@@ -12073,7 +15613,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "No, Keep as is"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "No, Keep as is"
           }
         },
@@ -12083,16 +15629,10 @@
             "value" : "No, conservare così com'è"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "いいえ、そのままで"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nei, behold som det er"
+            "state" : "new",
+            "value" : "No, Keep as is"
           }
         },
         "nl" : {
@@ -12107,16 +15647,16 @@
             "value" : "Nie, zachowaj jak jest"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não, manter como está"
+            "state" : "new",
+            "value" : "No, Keep as is"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu, păstrați așa cum este"
+            "state" : "new",
+            "value" : "No, Keep as is"
           }
         },
         "ru" : {
@@ -12143,9 +15683,21 @@
             "value" : "Hayır, olduğu gibi kalsın"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ні, залишити як є"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Không, giữ nguyên như vậy"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "No, Keep as is"
           }
         },
@@ -12163,13 +15715,7 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "لا، احتفظ بالمضخة كما هي"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ne, nechte čerpadlo tak, jak je"
+            "value" : "لا، إبقاء المضخة كما هي"
           }
         },
         "da" : {
@@ -12181,7 +15727,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nein, Pumpe so lassen wie sie ist"
+            "value" : "Nein, Pumpe unverändert behalten"
           }
         },
         "es" : {
@@ -12192,35 +15738,35 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ei, pidä pumppu sellaisenaan"
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Non, conserver la pompe en l'état"
+            "value" : "Non, garder la pompe telle quelle"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "No, Keep Pump As Is"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No, conservare la pompa così com'è"
+            "value" : "No, Tieni microinfusore Come È"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "いいえ、ポンプはそのままで"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nei, behold pumpen som den er"
@@ -12229,61 +15775,73 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nee, houd de pomp zoals hij is"
+            "value" : "Nee, pomp laten zoals hij is"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nie, zachowaj pompę w stanie, w jakim jest"
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não, mantenha a bomba como está"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu, păstrați pompa așa cum este"
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Нет, храните насос как есть"
+            "value" : "Нет, оставить как есть"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nie, nechajte čerpadlo tak, ako je"
+            "value" : "Nie, nechajte pumpu tak, ako je"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nej, behåll pumpen i befintligt skick"
+            "value" : "Nej, behåll pumptid"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hayır, Pompayı Olduğu Gibi Saklayın"
+            "value" : "Hayır güncelleme"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ні, залишити  як є"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Không, Giữ nguyên"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "No, Keep Pump As Is"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "不，保持泵原样"
+            "state" : "new",
+            "value" : "No, Keep Pump As Is"
           }
         }
       }
@@ -12294,109 +15852,133 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ملاحظة: مضخة DanaRS v1 غير مدعومة (حتى الآن). إذا كان لديك مضخة DanaRS v1 متاحة للاختبار، يُرجى الاتصال بباستيان فيرهاار!"
+            "value" : "ملاحظة: جهاز DanaRS v1 غير مدعوم (حالياً). إذا كان لديك مضخة DanaRS v1 متوفرة للاختبار، يُرجى التواصل مع Bastiaan Verhaar!"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "BEMÆRK: DanaRS v1 understøttes ikke (endnu). Hvis du har en DanaRS v1-pumpe til rådighed til test, bedes du kontakte Bastiaan Verhaar!"
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "HINWEIS: Die DanaRS v1 wird (noch) nicht unterstützt. Wenn Sie eine DanaRS v1 Pumpe zum Testen zur Verfügung haben, kontaktieren Sie bitte Bastiaan Verhaar!"
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "NOTA: DanaRS v1 no es compatible (todavía). Si dispone de una bomba DanaRS v1 para probarla, póngase en contacto con Bastiaan Verhaar."
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "HUOMAUTUS: DanaRS v1 ei ole tuettu (vielä). Jos sinulla on DanaRS v1 -pumppu testattavana, ota yhteyttä Bastiaan Verhaariin!"
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "NOTE : Le DanaRS v1 n'est pas (encore) supporté. Si vous avez une pompe DanaRS v1 disponible pour des tests, veuillez contacter Bastiaan Verhaar !"
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "NOTA: il DanaRS v1 non è ancora supportato. Se avete una pompa DanaRS v1 da testare, contattate Bastiaan Verhaar!"
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "MERK: DanaRS v1 støttes ikke (ennå). Hvis du har en DanaRS v1-pumpe tilgjengelig for testing, vennligst kontakt Bastiaan Verhaar!"
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LET OP: De DanaRS v1 wordt (nog) niet ondersteund. Als je een DanaRS v1 pomp beschikbaar hebt om te testen, neem dan contact op met Bastiaan Verhaar!"
+            "value" : "LET OP: De DanaRS v1 wordt (nog) niet ondersteund. Heb je een DanaRS v1 pomp beschikbaar om mee te testen? Neem dan contact op met Bastiaan Verhaar!"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "UWAGA: Pompa DanaRS v1 nie jest (jeszcze) obsługiwana. Jeśli masz pompę DanaRS v1 dostępną do testów, skontaktuj się z Bastiaanem Verhaarem!"
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "OBSERVAÇÃO: o DanaRS v1 não é compatível (ainda). Se você tiver uma bomba DanaRS v1 disponível para teste, entre em contato com Bastiaan Verhaar!"
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ПРИМЕЧАНИЕ: Насос DanaRS v1 не поддерживается (пока). Если у вас есть насос DanaRS v1, доступный для тестирования, пожалуйста, свяжитесь с Бастианом Верхааром!"
+            "value" : "ПРИМЕЧАНИЕ: DanaRS v1 пока не поддерживается. Если у вас есть помпа DanaRS v1 для тестирования, пожалуйста, свяжитесь с Бастианом Верхааром!"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "POZNÁMKA: DanaRS v1 nie je (zatiaľ) podporovaný. Ak máte k dispozícii čerpadlo DanaRS v1 na testovanie, kontaktujte Bastiaana Verhaara!"
+            "value" : "POZNÁMKA: DanaRS v1 zatiaľ nie je podporovaná. Ak máš k dispozícii pumpu DanaRS v1 na testovanie, kontaktuj prosím Bastiaan Verhaar!"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OBS: DanaRS v1 stöds inte (ännu). Om du har en DanaRS v1-pump tillgänglig för testning, vänligen kontakta Bastiaan Verhaar!"
+            "value" : "OBS: DanaRS v1 stöds inte (ännu). Om du har en DanaRS v1-pump tillgänglig för testning, kontakta Bastiaan Verhaar!"
           }
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "NOT: DanaRS v1 (henüz) desteklenmemektedir. Test için DanaRS v1 pompanız varsa, lütfen Bastiaan Verhaar ile iletişime geçin!"
+            "value" : "ПРИМІТКА: DanaRS v1 (поки що) не підтримується. Якщо у вас є помпа DanaRS v1 для тестування, зверніться до Бастіана Верхаара!"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "LƯU Ý: DanaRS v1 hiện chưa được hỗ trợ. Nếu bạn có sẵn một bơm DanaRS v1 để thử nghiệm, vui lòng liên hệ với Bastiaan Verhaar!"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "注意： 目前尚不支持 DanaRS v1。如果您有 DanaRS v1 泵可供测试，请联系 Bastiaan Verhaar！"
+            "state" : "new",
+            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         }
       }
@@ -12410,16 +15992,10 @@
             "value" : "ملاحظة: تحتوي مضخة دانا الخاصة بك على إعداد خاص يسمح لك بإسكات صوت تنبيه مضخة دانا. لتفعيل هذا الإعداد، يرجى الاتصال بموزع دانا الخاص بك"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poznámka: Čerpadlo Dana má speciální nastavení, které umožňuje ztišit zvukové signály čerpadla Dana. Chcete-li toto nastavení povolit, obraťte se na svého distributora Dana."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bemærk: Din Dana-pumpe har en særlig indstilling, som gør det muligt at dæmpe Dana-pumpens bip. Kontakt din Dana-distributør for at aktivere dette."
+            "value" : "Bemærk: Dana-pumpen har en særlig indstilling, der kan tavsgøre Dana-pumpens bip. Kontakt Dana-distributøren for at aktivere dette"
           }
         },
         "de" : {
@@ -12448,7 +16024,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Note: You Dana pump has a special setting which allows you to silence your Dana pump beeps. To enable this, please contact your Dana distributor"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Note: You Dana pump has a special setting which allows you to silence your Dana pump beeps. To enable this, please contact your Dana distributor"
           }
         },
@@ -12458,16 +16040,10 @@
             "value" : "Nota: la pompa Dana dispone di un'impostazione speciale che consente di silenziare i segnali acustici della pompa Dana. Per attivarla, contattare il proprio distributore Dana."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "注：Danaポンプには、Danaポンプのビープ音を無音にする特別な設定があります。これを有効にするには、Danaの販売代理店にお問い合わせください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Merk: Dana-pumpen har en spesiell innstilling som gjør at du kan dempe pipelyden i Dana-pumpen. Kontakt Dana-distributøren din for å aktivere dette"
+            "state" : "new",
+            "value" : "Note: You Dana pump has a special setting which allows you to silence your Dana pump beeps. To enable this, please contact your Dana distributor"
           }
         },
         "nl" : {
@@ -12482,28 +16058,28 @@
             "value" : "Uwaga: Pompa Dana ma specjalne ustawienie, które pozwala wyciszyć sygnały dźwiękowe pompy Dana. Aby to włączyć, skontaktuj się z dystrybutorem Dana"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Observação: Sua bomba Dana tem uma configuração especial que permite silenciar os bipes da bomba Dana. Para ativar essa configuração, entre em contato com o distribuidor Dana"
+            "state" : "new",
+            "value" : "Note: You Dana pump has a special setting which allows you to silence your Dana pump beeps. To enable this, please contact your Dana distributor"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notă: Pompa dvs. Dana are o setare specială care vă permite să reduceți la tăcere semnalele sonore ale pompei Dana. Pentru a activa acest lucru, vă rugăm să contactați distribuitorul Dana"
+            "state" : "new",
+            "value" : "Note: You Dana pump has a special setting which allows you to silence your Dana pump beeps. To enable this, please contact your Dana distributor"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Примечание: Насос Dana имеет специальную настройку, которая позволяет отключить звуковые сигналы насоса Dana. Чтобы включить эту функцию, обратитесь к дистрибьютору Dana."
+            "value" : "Примечание: Помпа Dana имеет специальную настройку, которая позволяет отключить звуковые сигналы. Чтобы включить эту функцию, обратитесь к дистрибьютору Dana"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Poznámka: Čerpadlo Dana má špeciálne nastavenie, ktoré umožňuje stlmiť zvukový signál čerpadla Dana. Ak chcete túto funkciu zapnúť, obráťte sa na svojho distribútora Dana"
+            "value" : "Poznámka: Pumpa Dana má špeciálne nastavenie, ktoré umožňuje stlmiť zvukový signál pumpy Dana. Ak chcete túto funkciu zapnúť, obráťte sa na svojho distribútora Dana"
           }
         },
         "sv" : {
@@ -12518,9 +16094,21 @@
             "value" : "Not: Dana pompanız, Dana pompa bip seslerini susturmanızı sağlayan özel bir ayara sahiptir. Bunu etkinleştirmek için lütfen Dana distribütörünüzle iletişime geçin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Примітка. Ваша помпа Dana має спеціальне налаштування, яке дозволяє вимкнути звукові сигнали помпи Dana. Щоб увімкнути це, зверніться до свого дистриб’ютора Dana"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Lưu ý: Máy bơm Dana của bạn có một cài đặt đặc biệt cho phép bạn tắt tiếng bíp của máy bơm Dana. Để bật chức năng này, vui lòng liên hệ với nhà phân phối Dana của bạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Note: You Dana pump has a special setting which allows you to silence your Dana pump beeps. To enable this, please contact your Dana distributor"
           }
         },
@@ -12539,12 +16127,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الانسداد"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Okluze"
           }
         },
         "da" : {
@@ -12567,19 +16149,25 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Occlusion"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Occlusion"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Occlusion"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Occlusion"
           }
         },
@@ -12589,16 +16177,10 @@
             "value" : "Occlusione"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "咬合"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Okklusjon"
+            "state" : "new",
+            "value" : "Occlusion"
           }
         },
         "nl" : {
@@ -12613,22 +16195,22 @@
             "value" : "Okluzja"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oclusão"
+            "state" : "new",
+            "value" : "Occlusion"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ocluzie"
+            "state" : "new",
+            "value" : "Occlusion"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Окклюзия"
+            "value" : "Закупорка"
           }
         },
         "sk" : {
@@ -12649,9 +16231,21 @@
             "value" : "Oklüzyon"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Закупорка"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Occlusion"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Occlusion"
           }
         },
@@ -12668,20 +16262,14 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "إيقاف التشغيل"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vypnuto"
+            "state" : "new",
+            "value" : "Off"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fra"
+            "value" : "Slukket"
           }
         },
         "de" : {
@@ -12693,24 +16281,30 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fuera de"
+            "value" : "Apagado"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Off"
+            "value" : "Pois päältä"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Arrêt"
+            "value" : "Désactivé"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "כבוי"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Off"
           }
         },
@@ -12720,13 +16314,7 @@
             "value" : "Spento"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "オフ"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Av"
@@ -12741,25 +16329,25 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wył."
+            "value" : "Wyłącz"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Off"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desligado"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oprit"
+            "state" : "new",
+            "value" : "Off"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "С сайта"
+            "value" : "Выключено"
           }
         },
         "sk" : {
@@ -12780,16 +16368,28 @@
             "value" : "Kapalı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вимкнути"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Tắt"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Off"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "关闭"
+            "state" : "new",
+            "value" : "Off"
           }
         }
       }
@@ -12801,12 +16401,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "حسناً"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
           }
         },
         "da" : {
@@ -12829,7 +16423,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
@@ -12841,7 +16435,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "OK"
           }
         },
@@ -12851,16 +16451,10 @@
             "value" : "OK"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
+            "value" : "Ok"
           }
         },
         "nl" : {
@@ -12871,32 +16465,26 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "OK"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "OK"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "OK"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "OK"
+            "value" : "ОК"
           }
         },
         "sk" : {
@@ -12917,42 +16505,182 @@
             "value" : "Tamam"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ОК"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "OK"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "好的"
+            "value" : "Ok"
           }
         }
       }
     },
     "Oke" : {
-      "comment" : "Dana-RS v3 pincode prompt oke"
+      "comment" : "Dana-RS v3 pincode prompt oke",
+      "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Oke"
+          }
+        }
+      }
     },
     "On" : {
       "comment" : "text on",
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "على"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Na adrese"
+            "state" : "new",
+            "value" : "On"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "På"
+            "value" : "Tændt"
           }
         },
         "de" : {
@@ -12964,43 +16692,43 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "En"
+            "value" : "Encendido"
           }
         },
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Osoitteessa"
+            "value" : "Päällä"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sur"
+            "value" : "Activé"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "דולק"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "On"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Su"
+            "value" : "Acceso"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "オン"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "On"
+            "value" : "På"
           }
         },
         "nl" : {
@@ -13012,31 +16740,31 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Na"
+            "value" : "Włącz"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "On"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Em"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pe"
+            "value" : "Ligado"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "На сайте"
+            "value" : "Включено"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Na stránke"
+            "value" : "Zapnuté"
           }
         },
         "sv" : {
@@ -13051,16 +16779,28 @@
             "value" : "Açık"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Увімкнути"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Bật"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "On"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "关于"
+            "value" : "开"
           }
         }
       }
@@ -13073,12 +16813,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "يتم دعم الجرعة التلقائية فقط"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podporován je pouze automatický bolus"
           }
         },
         "da" : {
@@ -13119,7 +16853,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Only Automatic Bolus is supported"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Only Automatic Bolus is supported"
           }
         },
@@ -13129,15 +16869,9 @@
             "value" : "È supportato solo il bolo automatico"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "自動ボーラスのみ対応"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Only Automatic Bolus is supported"
           }
         },
@@ -13153,16 +16887,16 @@
             "value" : "Obsługiwany jest tylko bolus automatyczny"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Somente o Bolus automático é suportado"
+            "state" : "new",
+            "value" : "Only Automatic Bolus is supported"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Numai Bolus automat este acceptat"
+            "state" : "new",
+            "value" : "Only Automatic Bolus is supported"
           }
         },
         "ru" : {
@@ -13189,16 +16923,28 @@
             "value" : "Yalnızca Otomatik Bolus desteklenir"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підтримується лише Автоматичний Болюс"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Chỉ hỗ trợ liều Bolus tự động"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Only Automatic Bolus is supported"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仅支持自动追加胰岛素"
+            "value" : "仅支持自动注射"
           }
         }
       }
@@ -13210,12 +16956,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "كلمة السر DanaRS v1"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Heslo DanaRS v1"
           }
         },
         "da" : {
@@ -13250,7 +16990,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Password DanaRS v1"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Password DanaRS v1"
           }
         },
@@ -13260,15 +17006,9 @@
             "value" : "Password DanaRS v1"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "パスワード DanaRS v1"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Password DanaRS v1"
           }
         },
@@ -13284,16 +17024,16 @@
             "value" : "Hasło DanaRS v1"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Senha DanaRS v1"
+            "state" : "new",
+            "value" : "Password DanaRS v1"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parolă DanaRS v1"
+            "state" : "new",
+            "value" : "Password DanaRS v1"
           }
         },
         "ru" : {
@@ -13320,9 +17060,21 @@
             "value" : "Şifre DanaRS v1"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Пароль DanaRS v1"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Mật khẩu DanaRS v1"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Password DanaRS v1"
           }
         },
@@ -13343,16 +17095,10 @@
             "value" : "الدبوس 1"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin 1"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pin 1"
+            "value" : "PIN 1"
           }
         },
         "de" : {
@@ -13381,7 +17127,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pin 1"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pin 1"
           }
         },
@@ -13391,15 +17143,9 @@
             "value" : "Pin 1"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ピン 1"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pin 1"
           }
         },
@@ -13411,26 +17157,26 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pin 1"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pin 1"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pino 1"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pin 1"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Контакт 1"
+            "value" : "ПИН 1"
           }
         },
         "sk" : {
@@ -13447,6 +17193,12 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Pin 1"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
             "value" : "Pin 1"
           }
@@ -13454,6 +17206,12 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Pin 1"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pin 1"
           }
         },
@@ -13474,16 +17232,10 @@
             "value" : "الدبوس 2"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pin 2"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pin 2"
+            "value" : "PIN 2"
           }
         },
         "de" : {
@@ -13512,7 +17264,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pin 2"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pin 2"
           }
         },
@@ -13522,15 +17280,9 @@
             "value" : "Pin 2"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ピン 2"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pin 2"
           }
         },
@@ -13542,26 +17294,26 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pin 2"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pin 2"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pino 2"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pin 2"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Контакт 2"
+            "value" : "ПИН 2"
           }
         },
         "sk" : {
@@ -13578,6 +17330,12 @@
         },
         "tr" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Pin 2"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
             "state" : "translated",
             "value" : "Pin 2"
           }
@@ -13585,6 +17343,12 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Pin 2"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pin 2"
           }
         },
@@ -13606,16 +17370,10 @@
             "value" : "الرمز البريدي مطلوب"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Požadovaný Pincode"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pinkode påkrævet"
+            "value" : "PIN-kode kræves"
           }
         },
         "de" : {
@@ -13650,7 +17408,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pincode required"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pincode required"
           }
         },
@@ -13660,15 +17424,9 @@
             "value" : "Pincode richiesto"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ピンコード必須"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pincode required"
           }
         },
@@ -13684,28 +17442,28 @@
             "value" : "Wymagany kod PIN"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pincode necessário"
+            "state" : "new",
+            "value" : "Pincode required"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cod pin necesar"
+            "state" : "new",
+            "value" : "Pincode required"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Требуется пинкод"
+            "value" : "Требуется ПИН-код"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Požadované PSČ"
+            "value" : "Požadovaný PIN kód"
           }
         },
         "sv" : {
@@ -13720,9 +17478,21 @@
             "value" : "Pin kodu gerekli"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Потрібен PIN-код"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Yêu cầu mã Pin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pincode required"
           }
         },
@@ -13744,16 +17514,10 @@
             "value" : "يُرجى التفكير في تغيير استراتيجية الجرعات في قائمة الإعدادات"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zvažte prosím změnu strategie dávkování v nabídce nastavení."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Overvej at ændre din doseringsstrategi i indstillingsmenuen"
+            "value" : "Overvej at ændre doseringsstrategien via indstillingsmenuen"
           }
         },
         "de" : {
@@ -13788,7 +17552,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Please consider changing your dosing strategy in the setting menu"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Please consider changing your dosing strategy in the setting menu"
           }
         },
@@ -13798,15 +17568,9 @@
             "value" : "Considerare la possibilità di modificare la strategia di dosaggio nel menu delle impostazioni."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定メニューで投与戦略の変更を検討してください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Please consider changing your dosing strategy in the setting menu"
           }
         },
@@ -13822,22 +17586,22 @@
             "value" : "Należy rozważyć zmianę strategii dozowania w menu ustawień"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Considere a possibilidade de alterar sua estratégia de dosagem no menu de configuração"
+            "state" : "new",
+            "value" : "Please consider changing your dosing strategy in the setting menu"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vă rugăm să luați în considerare schimbarea strategiei de dozare în meniul de setare"
+            "state" : "new",
+            "value" : "Please consider changing your dosing strategy in the setting menu"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Пожалуйста, рассмотрите возможность изменения стратегии дозирования в меню настроек"
+            "value" : "Пожалуйста, измените стратегию дозирования в меню настроек"
           }
         },
         "sk" : {
@@ -13858,16 +17622,28 @@
             "value" : "Lütfen ayar menüsünden dozaj stratejinizi değiştirmeyi düşünün"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Розгляньте можливість зміни стратегії дозування в меню налаштувань"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Vui lòng cân nhắc thay đổi liều lượng của bạn trong menu cài đặt"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Please consider changing your dosing strategy in the setting menu"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "请考虑在设置菜单中更改您的给药策略。"
+            "value" : "请考虑在设置菜单中更改配料策略"
           }
         }
       }
@@ -13875,6 +17651,132 @@
     "Prime amount" : {
       "comment" : "Label for tube refilled amount",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prime-mängd"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Prime amount"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13890,12 +17792,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "بطارية المضخة 0%"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baterie čerpadla 0%"
           }
         },
         "da" : {
@@ -13930,7 +17826,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump battery 0%"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump battery 0%"
           }
         },
@@ -13940,15 +17842,9 @@
             "value" : "Batteria della pompa 0%"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプ電池 0"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pump battery 0%"
           }
         },
@@ -13964,22 +17860,22 @@
             "value" : "Akumulator pompy 0%"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bateria da bomba 0%"
+            "state" : "new",
+            "value" : "Pump battery 0%"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baterie pompă 0%"
+            "state" : "new",
+            "value" : "Pump battery 0%"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Аккумулятор насоса 0%"
+            "value" : "Батарея помпы 0%"
           }
         },
         "sk" : {
@@ -14000,9 +17896,21 @@
             "value" : "Pompa aküsü %0"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Акумулятор Помпи 0%"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Pump battery 0%"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump battery 0%"
           }
         },
@@ -14024,16 +17932,10 @@
             "value" : "بطارية المضخة فارغة. استبدلها الآن!"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Baterie čerpadla je vybitá. Okamžitě ji vyměňte!"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pumpens batteri er tomt. Udskift det nu!"
+            "value" : "Pumpebatteriet er tomt. Udskift det nu!"
           }
         },
         "de" : {
@@ -14068,7 +17970,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump battery is empty. Replace it now!"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump battery is empty. Replace it now!"
           }
         },
@@ -14078,15 +17986,9 @@
             "value" : "La batteria della pompa è scarica. Sostituitela subito!"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプのバッテリーが空です。すぐに交換してください！"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pump battery is empty. Replace it now!"
           }
         },
@@ -14102,22 +18004,22 @@
             "value" : "Akumulator pompy jest rozładowany. Wymień go teraz!"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "A bateria da bomba está descarregada. Substitua-a agora!"
+            "state" : "new",
+            "value" : "Pump battery is empty. Replace it now!"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bateria pompei este descărcată. Înlocuiți-o acum!"
+            "state" : "new",
+            "value" : "Pump battery is empty. Replace it now!"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Батарея насоса разряжена. Замените его немедленно!"
+            "value" : "Батарея помпы разряжена. Замените ее немедленно!"
           }
         },
         "sk" : {
@@ -14138,9 +18040,21 @@
             "value" : "Pompa pili boşalmış. Hemen değiştirin!"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Батарея Помпи розряджена. Замініть його зараз!"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Pin của máy bơm đã hết. Hãy thay ngay!"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump battery is empty. Replace it now!"
           }
         },
@@ -14161,16 +18075,10 @@
             "value" : "يجب استبدال بطارية المضخة قريباً"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brzy je třeba vyměnit baterii čerpadla"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pumpens batteri skal snart udskiftes"
+            "value" : "Pumpebatteriet skal snart udskiftes"
           }
         },
         "de" : {
@@ -14199,7 +18107,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump battery needs to be replaced soon"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump battery needs to be replaced soon"
           }
         },
@@ -14209,15 +18123,9 @@
             "value" : "La batteria della pompa deve essere sostituita al più presto"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプのバッテリーはすぐに交換が必要"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pump battery needs to be replaced soon"
           }
         },
@@ -14233,28 +18141,28 @@
             "value" : "Akumulator pompy musi zostać wkrótce wymieniony"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "A bateria da bomba precisa ser substituída em breve"
+            "state" : "new",
+            "value" : "Pump battery needs to be replaced soon"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bateria pompei trebuie să fie înlocuită în curând"
+            "state" : "new",
+            "value" : "Pump battery needs to be replaced soon"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Аккумулятор насоса необходимо заменить в ближайшее время"
+            "value" : "Батарею помпы необходимо заменить в ближайшее время"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batéria čerpadla sa musí čoskoro vymeniť"
+            "value" : "Batériu pumpy bude potrebné čoskoro vymeniť"
           }
         },
         "sv" : {
@@ -14269,9 +18177,21 @@
             "value" : "Pompa aküsünün yakında değiştirilmesi gerekiyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Необхідно найближчим часом замінити акумулятор Помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Pin máy bơm cần được thay thế sớm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump battery needs to be replaced soon"
           }
         },
@@ -14290,12 +18210,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "خطأ في المضخة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Chyba čerpadla"
           }
         },
         "da" : {
@@ -14330,7 +18244,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump error"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump error"
           }
         },
@@ -14340,15 +18260,9 @@
             "value" : "Errore della pompa"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプエラー"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pump error"
           }
         },
@@ -14364,22 +18278,22 @@
             "value" : "Błąd pompy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erro da bomba"
+            "state" : "new",
+            "value" : "Pump error"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare pompă"
+            "state" : "new",
+            "value" : "Pump error"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ошибка насоса"
+            "value" : "Ошибка помпы"
           }
         },
         "sk" : {
@@ -14400,9 +18314,21 @@
             "value" : "Pompa hatası"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помилка Помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Pump error"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump error"
           }
         },
@@ -14423,16 +18349,10 @@
             "value" : "معلومات المضخة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informace o čerpadle"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Information om pumpen"
+            "value" : "Pumpeinformation"
           }
         },
         "de" : {
@@ -14461,7 +18381,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump information"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump information"
           }
         },
@@ -14471,15 +18397,9 @@
             "value" : "Informazioni sulla pompa"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプ情報"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pump information"
           }
         },
@@ -14495,28 +18415,28 @@
             "value" : "Informacje o pompie"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informações sobre a bomba"
+            "state" : "new",
+            "value" : "Pump information"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Informații despre pompă"
+            "state" : "new",
+            "value" : "Pump information"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Информация о насосе"
+            "value" : "Информация о помпе"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Informácie o čerpadle"
+            "value" : "Informácie o pumpe"
           }
         },
         "sv" : {
@@ -14531,9 +18451,21 @@
             "value" : "Pompa bilgileri"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Інформація про Помпу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Thông tin máy bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump information"
           }
         },
@@ -14548,6 +18480,132 @@
     "Pump is disconnected" : {
       "comment" : "Title disconnect warning notification",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pump är frånkopplad"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Pump is disconnected"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14563,12 +18621,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "لا تزال المضخة مفصولة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Čerpadlo je stále odpojeno"
           }
         },
         "da" : {
@@ -14603,7 +18655,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump is still disconnected"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump is still disconnected"
           }
         },
@@ -14613,15 +18671,9 @@
             "value" : "La pompa è ancora scollegata"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプはまだ接続されていない"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pump is still disconnected"
           }
         },
@@ -14637,22 +18689,22 @@
             "value" : "Pompa jest nadal odłączona"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "A bomba ainda está desconectada"
+            "state" : "new",
+            "value" : "Pump is still disconnected"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pompa este încă deconectată"
+            "state" : "new",
+            "value" : "Pump is still disconnected"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Насос по-прежнему отключен"
+            "value" : "Помпа по-прежнему отключена"
           }
         },
         "sk" : {
@@ -14673,9 +18725,21 @@
             "value" : "Pompanın bağlantısı hala kesik"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помпа все ще відключена"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Máy bơm vẫn chưa được ngắt kết nối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump is still disconnected"
           }
         },
@@ -14696,16 +18760,10 @@
             "value" : "اسم المضخة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Název čerpadla"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pumpens navn"
+            "value" : "Pumpenavn"
           }
         },
         "de" : {
@@ -14734,7 +18792,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump name"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump name"
           }
         },
@@ -14744,15 +18808,9 @@
             "value" : "Nome della pompa"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプ名"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pump name"
           }
         },
@@ -14768,28 +18826,28 @@
             "value" : "Nazwa pompy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nome da bomba"
+            "state" : "new",
+            "value" : "Pump name"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Denumirea pompei"
+            "state" : "new",
+            "value" : "Pump name"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Название насоса"
+            "value" : "Название помпы"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Názov čerpadla"
+            "value" : "Názov pumpy"
           }
         },
         "sv" : {
@@ -14804,9 +18862,21 @@
             "value" : "Pompa adı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Назва Помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Tên máy bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump name"
           }
         },
@@ -14825,12 +18895,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إيقاف تشغيل المضخة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vypnutí čerpadla"
           }
         },
         "da" : {
@@ -14865,7 +18929,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump shutdown"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump shutdown"
           }
         },
@@ -14875,15 +18945,9 @@
             "value" : "Arresto della pompa"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプ停止"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pump shutdown"
           }
         },
@@ -14899,22 +18963,22 @@
             "value" : "Wyłączenie pompy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Desligamento da bomba"
+            "state" : "new",
+            "value" : "Pump shutdown"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Oprirea pompei"
+            "state" : "new",
+            "value" : "Pump shutdown"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Отключение насоса"
+            "value" : "Отключение помпы"
           }
         },
         "sk" : {
@@ -14935,9 +18999,21 @@
             "value" : "Pompa kapatma"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відключення Помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Pump shutdown"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump shutdown"
           }
         },
@@ -14956,12 +19032,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "وقت المضخة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Doba čerpání"
           }
         },
         "da" : {
@@ -14996,7 +19066,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Pump time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump time"
           }
         },
@@ -15006,15 +19082,9 @@
             "value" : "Tempo di pompaggio"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプ時間"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Pump time"
           }
         },
@@ -15030,28 +19100,28 @@
             "value" : "Czas pracy pompy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tempo da bomba"
+            "state" : "new",
+            "value" : "Pump time"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timp de pompare"
+            "state" : "new",
+            "value" : "Pump time"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Время работы насоса"
+            "value" : "Время на помпе"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Čas čerpadla"
+            "value" : "Čas pumpy"
           }
         },
         "sv" : {
@@ -15066,9 +19136,21 @@
             "value" : "Pompa süresi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Час Помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Thời gian của Bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Pump time"
           }
         },
@@ -15090,16 +19172,10 @@
             "value" : "إعادة تمكين مزامنة البلعة؟"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Znovu povolit synchronizaci bolusu?"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Genaktiver bolus-synkronisering?"
+            "value" : "Genaktivér bolus-synkning?"
           }
         },
         "de" : {
@@ -15134,7 +19210,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Re-enable bolus syncing?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Re-enable bolus syncing?"
           }
         },
@@ -15144,15 +19226,9 @@
             "value" : "Riabilitare la sincronizzazione del bolo?"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーラス同期を再度有効にするか？"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Re-enable bolus syncing?"
           }
         },
@@ -15168,16 +19244,16 @@
             "value" : "Ponownie włączyć synchronizację bolusa?"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reativar a sincronização de bolus?"
+            "state" : "new",
+            "value" : "Re-enable bolus syncing?"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reactivarea sincronizării bolusurilor?"
+            "state" : "new",
+            "value" : "Re-enable bolus syncing?"
           }
         },
         "ru" : {
@@ -15204,16 +19280,28 @@
             "value" : "Bolus senkronizasyonunu yeniden etkinleştirin mi?"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторно ввімкнути синхронізацію болюсу?"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Bật lại tính năng đồng bộ bolus không?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Re-enable bolus syncing?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重新启用追加胰岛素同步？"
+            "value" : "重新启用栓剂同步？"
           }
         }
       }
@@ -15227,16 +19315,10 @@
             "value" : "تم استلام سلاسل سداسي عشري غير صالحة. حاول مرة أخرى"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přijaté neplatné hexadecimální řetězce. Zkuste to znovu"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Modtog ugyldige hex-strenge. Prøv igen"
+            "value" : "Ugyldige hex-strenge modtaget. Forsøg igen"
           }
         },
         "de" : {
@@ -15265,7 +19347,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Received invalid hex strings. Try again"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Received invalid hex strings. Try again"
           }
         },
@@ -15275,16 +19363,10 @@
             "value" : "Ricevute stringhe esadecimali non valide. Riprovare"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "無効な16進文字列を受信しました。再試行してください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mottok ugyldige hex-strenger. Prøv igjen"
+            "state" : "new",
+            "value" : "Received invalid hex strings. Try again"
           }
         },
         "nl" : {
@@ -15299,28 +19381,28 @@
             "value" : "Otrzymano nieprawidłowe ciągi szesnastkowe. Spróbuj ponownie"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recebeu strings hexadecimais inválidas. Tente novamente"
+            "state" : "new",
+            "value" : "Received invalid hex strings. Try again"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Am primit șiruri hexagonale invalide. Încercați din nou"
+            "state" : "new",
+            "value" : "Received invalid hex strings. Try again"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Получены недопустимые шестнадцатеричные строки. Попробуйте еще раз"
+            "value" : "Заданы недопустимые символы. Попробуйте еще раз"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prijaté neplatné hexadecimálne reťazce. Skúste to znova"
+            "value" : "Prijaté neplatné hexadecimálné reťazce. Skúste to znova"
           }
         },
         "sv" : {
@@ -15335,9 +19417,21 @@
             "value" : "Geçersiz hex dizeleri alındı. Tekrar deneyin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отримано недійсні шістнадцяткові рядки. Спробуйте знову"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Chuỗi hex không hợp lệ. Hãy thử lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Received invalid hex strings. Try again"
           }
         },
@@ -15358,16 +19452,10 @@
             "value" : "تم استلام أطوال الرمز السري غير صالحة. حاول مرة أخرى"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přijaté neplatné délky pincode. Zkuste to znovu"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Modtog ugyldige pinkodelængder. Prøv igen"
+            "value" : "Ugyldige PIN-kodelængder modtaget. Forsøg igen"
           }
         },
         "de" : {
@@ -15396,7 +19484,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Received invalid pincode lengths. Try again"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Received invalid pincode lengths. Try again"
           }
         },
@@ -15406,16 +19500,10 @@
             "value" : "Ricevuto pincode di lunghezza non valida. Riprovare"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "無効なピンコード長を受信しました。再試行してください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mottatt ugyldige pinkodelengder. Prøv igjen"
+            "state" : "new",
+            "value" : "Received invalid pincode lengths. Try again"
           }
         },
         "nl" : {
@@ -15430,28 +19518,28 @@
             "value" : "Otrzymano nieprawidłową długość kodu PIN. Spróbuj ponownie"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Comprimentos de código de barras inválidos recebidos. Tente novamente"
+            "state" : "new",
+            "value" : "Received invalid pincode lengths. Try again"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "S-au primit lungimi ale codului PIN invalide. Încercați din nou"
+            "state" : "new",
+            "value" : "Received invalid pincode lengths. Try again"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Получена неверная длина пинкода. Попробуйте еще раз"
+            "value" : "Неверная длина ПИН-кода. Попробуйте еще раз"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Prijaté neplatné dĺžky pincode. Skúste to znova"
+            "value" : "Neplatná dĺžka PIN kódu. Skúste to znova"
           }
         },
         "sv" : {
@@ -15466,9 +19554,21 @@
             "value" : "Geçersiz pin kodu uzunlukları alındı. Tekrar deneyin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отримано неправильну довжину пін-коду. Спробуйте знову"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Độ dài mã pin không hợp lệ. Hãy thử lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Received invalid pincode lengths. Try again"
           }
         },
@@ -15483,10 +19583,130 @@
     "Reconnect to pump" : {
       "comment" : "DanaKit reconnect",
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Koble til pumpen igjen"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Återanslut till pump"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reconnect to pump"
           }
         },
         "zh-Hans" : {
@@ -15507,16 +19727,10 @@
             "value" : "إعادة توصيل المضخة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Znovu připojte čerpadlo tp"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tilslut tp-pumpen igen"
+            "value" : "Gentilslut tp-pumpe"
           }
         },
         "de" : {
@@ -15551,7 +19765,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Reconnect tp pump"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reconnect tp pump"
           }
         },
@@ -15561,16 +19781,10 @@
             "value" : "Ricollegare la pompa tp"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプを再接続する"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Koble til tp-pumpen igjen"
+            "state" : "new",
+            "value" : "Reconnect tp pump"
           }
         },
         "nl" : {
@@ -15585,22 +19799,22 @@
             "value" : "Podłącz ponownie pompę tp"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reconectar a bomba tp"
+            "state" : "new",
+            "value" : "Reconnect tp pump"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reconectați pompa tp"
+            "state" : "new",
+            "value" : "Reconnect tp pump"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Снова подключите насос ТП"
+            "value" : "Переподключиться к помпе"
           }
         },
         "sk" : {
@@ -15621,9 +19835,21 @@
             "value" : "Tp pompasını yeniden bağlayın"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Підключіть помпу tp"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Kết nối lại máy bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reconnect tp pump"
           }
         },
@@ -15644,16 +19870,10 @@
             "value" : "إعادة الاتصال..."
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Obnovení spojení..."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "At genskabe forbindelsen..."
+            "value" : "Genforbinder..."
           }
         },
         "de" : {
@@ -15682,7 +19902,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Reconnecting..."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reconnecting..."
           }
         },
@@ -15692,16 +19918,10 @@
             "value" : "Riconnettersi..."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "再接続..."
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kobler til igjen..."
+            "state" : "new",
+            "value" : "Reconnecting..."
           }
         },
         "nl" : {
@@ -15712,26 +19932,26 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Reconnecting..."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reconnecting..."
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reconectando..."
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reconectarea..."
+            "state" : "new",
+            "value" : "Reconnecting..."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Воссоединение..."
+            "value" : "Переподключение..."
           }
         },
         "sk" : {
@@ -15752,9 +19972,21 @@
             "value" : "Yeniden bağlanıyor..."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Повторне підключення..."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đang kết nối lại..."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reconnecting..."
           }
         },
@@ -15773,12 +20005,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "كمية إعادة التعبئة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Množství náplně"
           }
         },
         "da" : {
@@ -15813,7 +20039,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Refill amount"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Refill amount"
           }
         },
@@ -15823,16 +20055,10 @@
             "value" : "Quantità di ricarica"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "補充量"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Påfyllingsmengde"
+            "state" : "new",
+            "value" : "Refill amount"
           }
         },
         "nl" : {
@@ -15847,28 +20073,28 @@
             "value" : "Ilość uzupełnienia"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quantidade de refil"
+            "state" : "new",
+            "value" : "Refill amount"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Cantitatea de reumplere"
+            "state" : "new",
+            "value" : "Refill amount"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Количество заправок"
+            "value" : "Остаток в резервуаре"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Množstvo náplne"
+            "value" : "Zostávajúci inzulín"
           }
         },
         "sv" : {
@@ -15883,9 +20109,21 @@
             "value" : "Dolum miktarı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "кількість заправок"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Số lượng nạp lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Refill amount"
           }
         },
@@ -15904,12 +20142,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "مستوى الأنسولين المتبقي"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zbývající hladina inzulínu"
           }
         },
         "da" : {
@@ -15944,7 +20176,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Remaining insulin level"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Remaining insulin level"
           }
         },
@@ -15954,16 +20192,10 @@
             "value" : "Livello di insulina rimanente"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "インスリン残量"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gjenværende insulinnivå"
+            "state" : "new",
+            "value" : "Remaining insulin level"
           }
         },
         "nl" : {
@@ -15978,22 +20210,22 @@
             "value" : "Pozostały poziom insuliny"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nível de insulina restante"
+            "state" : "new",
+            "value" : "Remaining insulin level"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nivelul rămas de insulină"
+            "state" : "new",
+            "value" : "Remaining insulin level"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Остаточный уровень инсулина"
+            "value" : "Количество оставшегося инсулина"
           }
         },
         "sk" : {
@@ -16014,9 +20246,21 @@
             "value" : "Kalan insülin seviyesi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Залишковий рівень інсуліну"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Mức insulin còn lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Remaining insulin level"
           }
         },
@@ -16037,16 +20281,10 @@
             "value" : "إزالة المضخة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Odstranění čerpadla"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fjern pumpen"
+            "value" : "Fjern pumpe"
           }
         },
         "de" : {
@@ -16058,13 +20296,13 @@
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Quitar la bomba"
+            "value" : "Retire la bomba"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Poista pumppu"
+            "state" : "new",
+            "value" : "Remove Pump"
           }
         },
         "fr" : {
@@ -16075,86 +20313,98 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Remove Pump"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Remove Pump"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rimuovere la pompa"
+            "value" : "Rimuovi microinfusore"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ポンプの取り外し"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Fjern pumpen"
+            "value" : "Fjern pumpe"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pomp verwijderen"
+            "value" : "Verwijder Pod"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Usuń pompę"
+            "state" : "new",
+            "value" : "Remove Pump"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Remove Pump"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Remover a bomba"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scoateți pompa"
+            "state" : "new",
+            "value" : "Remove Pump"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Снимите насос"
+            "value" : "Снимите Под"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Odstránenie čerpadla"
+            "value" : "Odstrániť Pod"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ta bort pumpen"
+            "value" : "Ta bort podd"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pompayı Çıkarın"
+            "value" : "Pompayı Çıkart"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зніміть Pod"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Thay bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Remove Pump"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "卸下泵"
+            "state" : "new",
+            "value" : "Remove Pump"
           }
         }
       }
@@ -16168,16 +20418,10 @@
             "value" : "عمر الخزان"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stáří nádrže"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reservoirets alder"
+            "value" : "Reservoiralder"
           }
         },
         "de" : {
@@ -16206,7 +20450,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Reservoir age"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir age"
           }
         },
@@ -16216,16 +20466,10 @@
             "value" : "Età del serbatoio"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "貯水池年齢"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reservoarets alder"
+            "state" : "new",
+            "value" : "Reservoir age"
           }
         },
         "nl" : {
@@ -16240,28 +20484,28 @@
             "value" : "Wiek zbiornika"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Idade do reservatório"
+            "state" : "new",
+            "value" : "Reservoir age"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vârsta rezervorului"
+            "state" : "new",
+            "value" : "Reservoir age"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Возраст водохранилища"
+            "value" : "Возраст резервуара"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vek nádrže"
+            "value" : "Vek zásobníka"
           }
         },
         "sv" : {
@@ -16276,9 +20520,21 @@
             "value" : "Rezervuar yaşı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "термін використовування Резервуару"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Reservoir age"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir age"
           }
         },
@@ -16302,7 +20558,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mængde i reservoiret"
+            "value" : "Reservoirmængde"
           }
         },
         "de" : {
@@ -16331,7 +20587,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Reservoir amount"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir amount"
           }
         },
@@ -16341,10 +20603,10 @@
             "value" : "Quantità del serbatoio"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reservoarmengde"
+            "value" : "Reservoar^beløp"
           }
         },
         "nl" : {
@@ -16359,10 +20621,16 @@
             "value" : "Pojemność zbiornika"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Reservoir amount"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quantidade do reservatório"
+            "state" : "new",
+            "value" : "Reservoir amount"
           }
         },
         "ru" : {
@@ -16389,9 +20657,21 @@
             "value" : "Rezervuar miktarı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Объем Резервуара"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Lượng bình chứa"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir amount"
           }
         },
@@ -16410,12 +20690,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الخزان والقنية"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zásobník a kanyla"
           }
         },
         "da" : {
@@ -16450,7 +20724,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Reservoir and cannula"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir and cannula"
           }
         },
@@ -16460,16 +20740,10 @@
             "value" : "Serbatoio e cannula"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "リザーバーとカニューレ"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reservoar og kanyle"
+            "state" : "new",
+            "value" : "Reservoir and cannula"
           }
         },
         "nl" : {
@@ -16484,16 +20758,16 @@
             "value" : "Zbiornik i kaniula"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reservatório e cânula"
+            "state" : "new",
+            "value" : "Reservoir and cannula"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rezervor și canulă"
+            "state" : "new",
+            "value" : "Reservoir and cannula"
           }
         },
         "ru" : {
@@ -16520,9 +20794,21 @@
             "value" : "Rezervuar ve kanül"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Резервуара та Канюля"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Reservoir và cannula"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir and cannula"
           }
         },
@@ -16543,16 +20829,10 @@
             "value" : "الخزان فارغ. استبدله الآن!"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nádrž je prázdná. Okamžitě ji vyměňte!"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reservoiret er tomt. Udskift den nu!"
+            "value" : "Reservoiret er tomt. Udskift det nu!"
           }
         },
         "de" : {
@@ -16581,7 +20861,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Reservoir is empty. Replace it now!"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir is empty. Replace it now!"
           }
         },
@@ -16591,16 +20877,10 @@
             "value" : "Il serbatoio è vuoto. Sostituirlo subito!"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "リザーバーが空です。すぐに交換してください！"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reservoaret er tomt. Bytt det ut nå!"
+            "state" : "new",
+            "value" : "Reservoir is empty. Replace it now!"
           }
         },
         "nl" : {
@@ -16615,16 +20895,16 @@
             "value" : "Zbiornik jest pusty. Wymień go teraz!"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "O reservatório está vazio. Substitua-o agora!"
+            "state" : "new",
+            "value" : "Reservoir is empty. Replace it now!"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rezervorul este gol. Înlocuiți-l acum!"
+            "state" : "new",
+            "value" : "Reservoir is empty. Replace it now!"
           }
         },
         "ru" : {
@@ -16636,7 +20916,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nádrž je prázdna. Vymeňte ju teraz!"
+            "value" : "Zásobník je prázdna. Teraz ho vymeňte!"
           }
         },
         "sv" : {
@@ -16651,9 +20931,21 @@
             "value" : "Rezervuar boşalmış. Hemen değiştirin!"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Резервуар порожній. Замініть його зараз!"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Bình chứa đã cạn. Hãy thay thế ngay!"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir is empty. Replace it now!"
           }
         },
@@ -16674,16 +20966,10 @@
             "value" : "إعادة تعبئة الخزان/كانولا"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Doplňování nádržky/kanystru"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Genopfyldning af reservoir/kanyle"
+            "value" : "Reservoir-/kanylegenopfyldning"
           }
         },
         "de" : {
@@ -16712,7 +20998,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Reservoir/cannula refill"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir/cannula refill"
           }
         },
@@ -16722,16 +21014,10 @@
             "value" : "Ricarica del serbatoio/cannula"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "リザーバー／カニューレ再充填"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Påfylling av reservoar/kanyle"
+            "state" : "new",
+            "value" : "Reservoir/cannula refill"
           }
         },
         "nl" : {
@@ -16746,16 +21032,16 @@
             "value" : "Uzupełnianie zbiornika/kaniuli"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Recarga do reservatório/cânula"
+            "state" : "new",
+            "value" : "Reservoir/cannula refill"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reumplere rezervor/canulă"
+            "state" : "new",
+            "value" : "Reservoir/cannula refill"
           }
         },
         "ru" : {
@@ -16767,7 +21053,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Doplnenie zásobníka/kanvy"
+            "value" : "Plnenie zásobníka/kanyly"
           }
         },
         "sv" : {
@@ -16782,9 +21068,21 @@
             "value" : "Rezervuar/kanül dolumu"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "заправка Резервуару/Канюлі"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Nạp lại Reservoir/cannula"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Reservoir/cannula refill"
           }
         },
@@ -16801,26 +21099,20 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "السيرة الذاتية"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Životopis"
+            "state" : "new",
+            "value" : "Resume"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "CV"
+            "value" : "Genoptag"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lebenslauf"
+            "value" : "Fortsetzen"
           }
         },
         "es" : {
@@ -16831,20 +21123,26 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Yhteenveto"
+            "state" : "new",
+            "value" : "Resume"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Curriculum vitae"
+            "value" : "Reprendre"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Resume"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Visszatérés"
           }
         },
         "it" : {
@@ -16853,16 +21151,10 @@
             "value" : "Riprendi"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "履歴書"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Gjenoppta"
+            "value" : "Gjenoppta leveranse"
           }
         },
         "nl" : {
@@ -16873,20 +21165,20 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wznowiono"
+            "state" : "new",
+            "value" : "Resume"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Currículo"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reluați"
+            "state" : "new",
+            "value" : "Resume"
           }
         },
         "ru" : {
@@ -16898,13 +21190,13 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Životopis"
+            "value" : "Pokračovať"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Meritförteckning"
+            "value" : "Återuppta"
           }
         },
         "tr" : {
@@ -16913,16 +21205,28 @@
             "value" : "Devam et"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відновити"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Tiếp tục"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Resume"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "简历"
+            "value" : "恢复"
           }
         }
       }
@@ -16932,65 +21236,59 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "استئناف التسليم"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Dodání životopisu"
+            "state" : "new",
+            "value" : "Resume delivery"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Levering af CV"
+            "value" : "Fortsæt indgivelse"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lieferung starten"
+            "value" : "Insulinabgabe fortsetzen"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Entrega de currículum"
+            "value" : "Reanudar la entrega de insulina"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Jatko-osan toimitus"
+            "state" : "new",
+            "value" : "Resume delivery"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Remise de curriculum vitae"
+            "value" : "Reprendre l'administration"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Resume delivery"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Resume delivery"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Consegna del curriculum"
+            "value" : "Riprendi erogazione"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "履歴書の送付"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Gjenoppta levering"
@@ -16999,61 +21297,73 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hervatten"
+            "value" : "Hervat toediening"
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wznowienie dostawy"
+            "value" : "Wznów podawanie"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Resume delivery"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Entrega de currículos"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Livrarea CV-ului"
+            "state" : "new",
+            "value" : "Resume delivery"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Доставка резюме"
+            "value" : "Возобновить подачу"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Doručenie životopisu"
+            "value" : "Obnoviť podávanie inzulínu"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Leverans av CV"
+            "value" : "Återuppta insulintillförsel"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Özgeçmiş teslimatı"
+            "value" : "İletimi Devam Ettir"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Відновити доставку"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Tiếp tục lại việc tiêm insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Resume delivery"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "简历交付"
+            "state" : "new",
+            "value" : "Resume delivery"
           }
         }
       }
@@ -17064,25 +21374,19 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الحفظ"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uložit"
+            "value" : "إحفظ"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gemme"
+            "value" : "Gem"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Speichern in Pumpe"
+            "value" : "Speichern"
           }
         },
         "es" : {
@@ -17100,28 +21404,28 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Économiser"
+            "value" : "Sauvegarder"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Save"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Elment"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Risparmiare"
+            "value" : "Salva"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "セーブ"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lagre"
@@ -17139,16 +21443,16 @@
             "value" : "Zapisz"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salvar"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Salvați"
+            "value" : "Salvar"
           }
         },
         "ru" : {
@@ -17175,26 +21479,158 @@
             "value" : "Kaydet"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зберегти"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Lưu"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Save"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "节省"
+            "value" : "保存​​"
           }
         }
       }
     },
     "Scan" : {
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Søk"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skanna"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scan"
           }
         },
         "zh-Hans" : {
@@ -17211,91 +21647,85 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "المسح الضوئي"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skenování"
+            "value" : "يتم المسح"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Scanning"
+            "value" : "Skanner"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Scannen"
+            "value" : "Scannt"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Escaneado"
+            "value" : "Buscando"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skannaus"
+            "state" : "new",
+            "value" : "Scanning"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Numérisation"
+            "value" : "Balayage"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Scanning"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Scanning"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Scansione"
+            "value" : "Lettura"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "スキャニング"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Søker"
+            "value" : "Skanner"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Scannen"
+            "value" : "Aan het scannen"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Skanowanie"
+            "state" : "new",
+            "value" : "Scanning"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scanning"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Digitalização"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Scanare"
+            "state" : "new",
+            "value" : "Scanning"
           }
         },
         "ru" : {
@@ -17307,31 +21737,43 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Skenovanie"
+            "value" : "Skenuje sa"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Skanning"
+            "value" : "Skannar"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tarama"
+            "value" : "Taranıyor"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сканування"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đang quét"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Scanning"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "扫描"
+            "state" : "new",
+            "value" : "Scanning"
           }
         }
       }
@@ -17342,64 +21784,58 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "القاعدية المجدولة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Plánovaný bazální"
+            "value" : "الجرعة الأساسية المجدولة"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Planlagt basal"
+            "value" : "Planlagt Basal"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Geplant Basal"
+            "value" : "Geplante Basalrate"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basal programado"
+            "value" : "Basal programada"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Aikataulun mukainen Basal"
+            "state" : "new",
+            "value" : "Scheduled Basal"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basale programmée"
+            "value" : "Basal programmé"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Scheduled Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Scheduled Basal"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basale programmato"
+            "value" : "Basale programmata"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "予定ベース"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Planlagt basal"
@@ -17408,61 +21844,73 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gepland Basaal"
+            "value" : "Gepland basaal"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zaplanowane podstawowe"
+            "state" : "new",
+            "value" : "Scheduled Basal"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Scheduled Basal"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Basal programado"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bazal programat"
+            "state" : "new",
+            "value" : "Scheduled Basal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Плановая базальная"
+            "value" : "Запланированный Базал"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Plánovaná základná"
+            "value" : "Naplánovaný bazál"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Schemalagd Basal"
+            "value" : "Schemalagd basal"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Planlanmış Bazal"
+            "value" : "Programlanmış Bazal"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Запланований Базал"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã lên chương trình cho liều Basal"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Scheduled Basal"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "预定的基质"
+            "value" : "预设基础率"
           }
         }
       }
@@ -17476,16 +21924,10 @@
             "value" : "وظيفة التمرير"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Funkce posouvání"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Scroll-funktion"
+            "value" : "Rullefunktion"
           }
         },
         "de" : {
@@ -17514,7 +21956,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Scroll function"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Scroll function"
           }
         },
@@ -17524,16 +21972,10 @@
             "value" : "Funzione di scorrimento"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "スクロール機能"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Rulle funksjon"
+            "state" : "new",
+            "value" : "Scroll function"
           }
         },
         "nl" : {
@@ -17548,16 +21990,16 @@
             "value" : "Funkcja przewijania"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Função de rolagem"
+            "state" : "new",
+            "value" : "Scroll function"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Funcția de derulare"
+            "state" : "new",
+            "value" : "Scroll function"
           }
         },
         "ru" : {
@@ -17569,7 +22011,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Funkcia posúvania"
+            "value" : "Posúvanie tlačidlom"
           }
         },
         "sv" : {
@@ -17584,9 +22026,21 @@
             "value" : "Kaydırma işlevi"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Функція прокрутки"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Chức năng cuộn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Scroll function"
           }
         },
@@ -17607,45 +22061,45 @@
             "value" : "ثانية"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "sec"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "sek."
+            "value" : "sek"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "sec"
+            "value" : "sek"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "sec"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "sec"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "sec"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "sec"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "sec"
           }
         },
@@ -17655,15 +22109,9 @@
             "value" : "sec"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "秒"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "sec"
           }
         },
@@ -17679,15 +22127,15 @@
             "value" : "sek"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "sec"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "sec"
           }
         },
@@ -17715,9 +22163,21 @@
             "value" : "sn"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "секунд"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "sec"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "sec"
           }
         },
@@ -17732,16 +22192,136 @@
     "Select insulin type" : {
       "comment" : "Title for insulin type",
       "localizations" : {
-        "nb" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Velg insulintype"
+            "value" : "Selecteer type insuline"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выбрать тип инсулина"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vybrať typ inzulínu"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välj insulintyp"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть тип Інсуліну"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn loại insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select insulin type"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择胰岛素类型"
+            "state" : "new",
+            "value" : "Select insulin type"
           }
         }
       }
@@ -17754,12 +22334,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "اختر نوع الأنسولين"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vyberte typ inzulínu"
           }
         },
         "da" : {
@@ -17800,7 +22374,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Select insulin Type"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Select insulin Type"
           }
         },
@@ -17810,16 +22390,10 @@
             "value" : "Selezionare il tipo di insulina"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "インスリンタイプを選択"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velg insulintype"
+            "state" : "new",
+            "value" : "Select insulin Type"
           }
         },
         "nl" : {
@@ -17834,16 +22408,16 @@
             "value" : "Wybierz typ insuliny"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecione o tipo de insulina"
+            "state" : "new",
+            "value" : "Select insulin Type"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selectați tipul de insulină"
+            "state" : "new",
+            "value" : "Select insulin Type"
           }
         },
         "ru" : {
@@ -17870,9 +22444,21 @@
             "value" : "İnsülin Tipini Seçin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть тип інсуліну"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Chọn loại insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Select insulin Type"
           }
         },
@@ -17893,16 +22479,10 @@
             "value" : "حدد نوع الأنسولين الذي ستستخدمه في هذه المضخة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vyberte typ inzulínu, který budete v této pumpě používat."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vælg den type insulin, du vil bruge i denne pumpe"
+            "value" : "Vælg insulintypen, pumpen skal anvende"
           }
         },
         "de" : {
@@ -17931,7 +22511,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Select the type of insulin that you will be using in this pump"
           }
         },
@@ -17941,16 +22527,10 @@
             "value" : "Selezionare il tipo di insulina da utilizzare in questo microinfusore"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "このポンプで使用するインスリンの種類を選択してください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velg insulintypen du vil bruke i denne pumpen"
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump"
           }
         },
         "nl" : {
@@ -17965,16 +22545,16 @@
             "value" : "Wybierz typ insuliny, która będzie używana w tej pompie."
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecione o tipo de insulina que você usará nessa bomba"
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selectați tipul de insulină pe care îl veți utiliza în această pompă"
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump"
           }
         },
         "ru" : {
@@ -18001,9 +22581,21 @@
             "value" : "Bu pompada kullanacağınız insülin türünü seçin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть тип інсуліну, який ви будете використовувати в цій помпі"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Chọn loại insulin mà bạn sẽ sử dụng trong máy bơm này"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Select the type of insulin that you will be using in this pump"
           }
         },
@@ -18018,16 +22610,136 @@
     "Select the type of insulin that you will be using in this pump." : {
       "comment" : "Title text for insulin type confirmation page",
       "localizations" : {
-        "nb" : {
+        "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Velg insulintypen du vil bruke i denne pumpen."
+            "value" : "حدد نوع الأنسولين الذي ستستخدمه في هذه المضخة."
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vælg den type insulin, du skal bruge i denne pumpe."
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wählen Sie die Art des Insulins aus, die Sie in dieser Pumpe verwenden möchten."
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleccione el tipo de insulina que utilizará en esta bomba."
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Valitse insuliinin tyyppi, jota käytät tässä pumpussa."
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sélectionnez le type d'insuline que vous utiliserez dans cette pompe."
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Seleziona il tipo di insulina che utilizzerai in questo microinfusore."
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Velg hvilken type insulin du skal bruke i denne pumpen."
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selecteer het type insuline dat je in deze pomp gaat gebruiken."
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Wybierz rodzaj insuliny, której będziesz używać w pompie."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Выберите тип инсулина, который вы будете использовать в этой помпе."
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vyberte typ inzulínu, ktorý budete v tejto pumpe používať."
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Välj vilken typ av insulin du kommer att använda."
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bu pompada kullanacağınız insülin tipini seçin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть тип інсуліну, який ви будете використовувати у цій поспі."
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chọn loại insulin bạn sẽ sử dụng trong máy bơm này."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "选择您将在此泵中使用的胰岛素类型。"
+            "state" : "new",
+            "value" : "Select the type of insulin that you will be using in this pump."
           }
         }
       }
@@ -18041,16 +22753,10 @@
             "value" : "اختر المضخة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vyberte si své čerpadlo"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vælg din pumpe"
+            "value" : "Vælg pumpemodel"
           }
         },
         "de" : {
@@ -18079,7 +22785,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Select your pump"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Select your pump"
           }
         },
@@ -18089,22 +22801,16 @@
             "value" : "Selezionare la pompa"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプの選択"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Velg din pumpe"
+            "state" : "new",
+            "value" : "Select your pump"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Selecteer uw pomp"
+            "value" : "Selecteer je pomp"
           }
         },
         "pl" : {
@@ -18113,28 +22819,28 @@
             "value" : "Wybierz pompę"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selecione sua bomba"
+            "state" : "new",
+            "value" : "Select your pump"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Selectați pompa dvs."
+            "state" : "new",
+            "value" : "Select your pump"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Выберите свой насос"
+            "value" : "Выберите Вашу помпу"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vyberte si svoje čerpadlo"
+            "value" : "Vyberte si svoju pumpu"
           }
         },
         "sv" : {
@@ -18149,9 +22855,21 @@
             "value" : "Pompanızı seçin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виберіть свою Помпу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Chọn máy bơm của bạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Select your pump"
           }
         },
@@ -18170,12 +22888,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تعيين تذكير لقطع الاتصال"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nastavení připomenutí odpojení"
           }
         },
         "da" : {
@@ -18210,7 +22922,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Set reminder for disconnect"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Set reminder for disconnect"
           }
         },
@@ -18220,16 +22938,10 @@
             "value" : "Impostare un promemoria per la disconnessione"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "切断のリマインダーを設定する"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi påminnelse for frakobling"
+            "state" : "new",
+            "value" : "Set reminder for disconnect"
           }
         },
         "nl" : {
@@ -18244,22 +22956,22 @@
             "value" : "Ustaw przypomnienie o rozłączeniu"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Definir lembrete para desconexão"
+            "state" : "new",
+            "value" : "Set reminder for disconnect"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Setați un memento pentru deconectare"
+            "state" : "new",
+            "value" : "Set reminder for disconnect"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Установите напоминание об отключении"
+            "value" : "Установить напоминание при отключении"
           }
         },
         "sk" : {
@@ -18280,9 +22992,21 @@
             "value" : "Bağlantıyı kesmek için hatırlatıcı ayarlayın"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Встановити нагадування про відключення"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đặt lời nhắc ngắt kết nối"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Set reminder for disconnect"
           }
         },
@@ -18304,16 +23028,10 @@
             "value" : "اضبط ملف التعريف القاعدي الذي يجب أن تستخدمه المضخة. لاحظ أنه سيحل محل الملف الشخصي الموجود في المضخة بالملف الشخصي الموجود في %1$@"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nastavte bazální profil, který má čerpadlo používat. Všimněte si, že se přepíše profil, který je v čerpadle, profilem na %1$@."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indstil den basalprofil, som pumpen skal bruge. Bemærk, at det vil overskrive den profil, der er i pumpen, med den, der er i %1$@"
+            "value" : "Indstil basalprofilen pumpen skal anvende. Bemærk, at pumpens interne profil overskrives med den fra %1$@"
           }
         },
         "de" : {
@@ -18348,7 +23066,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Set the basal profile the pump should use. Note, that it will overwrite the profile that is in the pump, with the one in %1$@"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Set the basal profile the pump should use. Note, that it will overwrite the profile that is in the pump, with the one in %1$@"
           }
         },
@@ -18358,16 +23082,10 @@
             "value" : "Imposta il profilo basale che il microinfusore deve utilizzare. Si noti che il profilo presente nel microinfusore verrà sovrascritto con quello presente in %1$@."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプが使用する基礎プロフィールを設定する。ポンプに内蔵されているプロファイルを、 %1$@のプロファイルで上書きすることに注意してください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Angi basalprofilen pumpen skal bruke. Merk at den vil overskrive profilen som er i pumpen, med profilen i %1$@"
+            "state" : "new",
+            "value" : "Set the basal profile the pump should use. Note, that it will overwrite the profile that is in the pump, with the one in %1$@"
           }
         },
         "nl" : {
@@ -18382,22 +23100,22 @@
             "value" : "Ustaw profil podstawowy, którego powinna używać pompa. Należy pamiętać, że spowoduje to nadpisanie profilu znajdującego się w pompie profilem znajdującym się na stronie %1$@."
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Defina o perfil basal que a bomba deve usar. Observe que isso substituirá o perfil que está na bomba pelo que está em %1$@"
+            "state" : "new",
+            "value" : "Set the basal profile the pump should use. Note, that it will overwrite the profile that is in the pump, with the one in %1$@"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Setează profilul bazal pe care pompa ar trebui să îl utilizeze. Rețineți că se va suprascrie profilul care se află în pompă, cu cel din %1$@"
+            "state" : "new",
+            "value" : "Set the basal profile the pump should use. Note, that it will overwrite the profile that is in the pump, with the one in %1$@"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Установите базальный профиль, который должен использовать насос. Обратите внимание, что при этом профиль, установленный в насосе, будет заменен профилем, установленным в %1$@."
+            "value" : "Установите базальный профиль, который должна использовать помпа. Обратите внимание, что при этом профиль, установленный в помпе, будет заменен профилем, установленным в %1$@"
           }
         },
         "sk" : {
@@ -18418,9 +23136,21 @@
             "value" : "Pompanın kullanması gereken bazal profili ayarlayın. Pompada bulunan profilin üzerine %1$@adresinde bulunan profilin yazılacağını unutmayın."
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Встановіть базальний профіль, який повинен використовувати помпа. Зауважте, що це перезапише профіль, який знаходиться в помпі, на профілю у %1$@"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đặt cấu hình cơ bản mà máy bơm nên sử dụng. Lưu ý rằng nó sẽ ghi đè lên cấu hình có trong máy bơm, với cấu hình trong %1$@"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Set the basal profile the pump should use. Note, that it will overwrite the profile that is in the pump, with the one in %1$@"
           }
         },
@@ -18442,16 +23172,10 @@
             "value" : "ضبط درجة الحرارة الأساسية غير مدعوم في الوقت الحالي"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nastavení bazální teploty není v tuto chvíli podporováno."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indstilling af basaltemperatur understøttes ikke på nuværende tidspunkt"
+            "value" : "Indstilling af basaltemperatur understøttes p.t. ikke"
           }
         },
         "de" : {
@@ -18486,7 +23210,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Setting temp basal is not supported at this time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Setting temp basal is not supported at this time"
           }
         },
@@ -18496,16 +23226,10 @@
             "value" : "L'impostazione della temp basale non è attualmente supportata."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "基礎体温の設定は現在サポートされていません。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Innstilling av temp basal støttes ikke for øyeblikket"
+            "state" : "new",
+            "value" : "Setting temp basal is not supported at this time"
           }
         },
         "nl" : {
@@ -18520,28 +23244,28 @@
             "value" : "Ustawienie podstawowej temperatury nie jest obecnie obsługiwane."
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "A configuração da temperatura basal não é suportada no momento"
+            "state" : "new",
+            "value" : "Setting temp basal is not supported at this time"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Setarea temp basal nu este susținută în acest moment"
+            "state" : "new",
+            "value" : "Setting temp basal is not supported at this time"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Установка базальной температуры на данный момент не поддерживается"
+            "value" : "Установка временной базальной скорости на данный момент не поддерживается"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nastavenie bazálnej teploty nie je v súčasnosti podporované"
+            "value" : "Nastavenie dočasného bazálu nie je v súčasnosti podporované"
           }
         },
         "sv" : {
@@ -18556,9 +23280,21 @@
             "value" : "Geçici bazal ayarı şu anda desteklenmemektedir"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Встановлення тимчасового базалу наразі не підтримується"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Cài đặt liều temp basal không được hỗ trợ tại thời điểm này"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Setting temp basal is not supported at this time"
           }
         },
@@ -18577,12 +23313,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إعداد دانا-i"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nastavení Dana-i"
           }
         },
         "da" : {
@@ -18617,7 +23347,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Setting up Dana-i"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Setting up Dana-i"
           }
         },
@@ -18627,15 +23363,9 @@
             "value" : "Impostazione di Dana-i"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダナアイの設定"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Setting up Dana-i"
           }
         },
@@ -18651,16 +23381,16 @@
             "value" : "Konfiguracja Dana-i"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurando a Dana-i"
+            "state" : "new",
+            "value" : "Setting up Dana-i"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurarea Dana-i"
+            "state" : "new",
+            "value" : "Setting up Dana-i"
           }
         },
         "ru" : {
@@ -18687,9 +23417,21 @@
             "value" : "Dana-i'nin Kurulumu"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Налаштування Dana-i"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Thiết lập Dana-i"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Setting up Dana-i"
           }
         },
@@ -18708,12 +23450,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إعداد DanaRS v1"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nastavení systému DanaRS v1"
           }
         },
         "da" : {
@@ -18748,7 +23484,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Setting up DanaRS v1"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Setting up DanaRS v1"
           }
         },
@@ -18758,15 +23500,9 @@
             "value" : "Impostazione di DanaRS v1"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "DanaRS v1のセットアップ"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Setting up DanaRS v1"
           }
         },
@@ -18782,16 +23518,16 @@
             "value" : "Konfiguracja DanaRS v1"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuração do DanaRS v1"
+            "state" : "new",
+            "value" : "Setting up DanaRS v1"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurarea DanaRS v1"
+            "state" : "new",
+            "value" : "Setting up DanaRS v1"
           }
         },
         "ru" : {
@@ -18818,9 +23554,21 @@
             "value" : "DanaRS v1'in Kurulumu"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Налаштування DanaRS v1"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Thiết lập DanaRS v1"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Setting up DanaRS v1"
           }
         },
@@ -18839,12 +23587,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "إعداد DanaRS v3"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nastavení systému DanaRS v3"
           }
         },
         "da" : {
@@ -18879,7 +23621,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Setting up DanaRS v3"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Setting up DanaRS v3"
           }
         },
@@ -18889,15 +23637,9 @@
             "value" : "Impostazione di DanaRS v3"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "DanaRS v3のセットアップ"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Setting up DanaRS v3"
           }
         },
@@ -18913,16 +23655,16 @@
             "value" : "Konfiguracja DanaRS v3"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configuração do DanaRS v3"
+            "state" : "new",
+            "value" : "Setting up DanaRS v3"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Configurarea DanaRS v3"
+            "state" : "new",
+            "value" : "Setting up DanaRS v3"
           }
         },
         "ru" : {
@@ -18949,9 +23691,21 @@
             "value" : "DanaRS v3'ün Kurulumu"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Налаштування DanaRS v3"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Thiết lập DanaRS v3"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Setting up DanaRS v3"
           }
         },
@@ -18966,10 +23720,136 @@
     "Setup Complete" : {
       "comment" : "Title for setup complete",
       "localizations" : {
-        "zh-Hans" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Setup Complete"
+          }
+        },
+        "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "设置完成"
+            "value" : "Opsætning fuldført"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setup vollständig"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configuración completada"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Setup Complete"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mise en place terminée"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Setup Complete"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Setup Complete"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Installazione Completata"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oppsett ferdig"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setup voltooid"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Setup Complete"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Setup Complete"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Setup Complete"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Настройка завершена"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nastavenie je dokončené"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inställning färdig"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kurulum tamamlandı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Налаштування Завершено"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cài đặt hoàn thành"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Setup Complete"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Setup Complete"
           }
         }
       }
@@ -18983,16 +23863,10 @@
             "value" : "مشاركة سجلات مضخة دانا"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sdílet protokoly čerpadla Dana"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Del Danas pumpelogs"
+            "value" : "Del Dana-pumpelogger"
           }
         },
         "de" : {
@@ -19021,25 +23895,25 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Share Dana pump logs"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Share Dana pump logs"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Condividi i registri della pompa Dana"
+            "value" : "Condividi i registri delle pompe Dana"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ダナ・ポンプの記録を共有する"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Share Dana pump logs"
           }
         },
@@ -19055,28 +23929,28 @@
             "value" : "Udostępnij dzienniki pomp Dana"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Compartilhe os registros da bomba Dana"
+            "state" : "new",
+            "value" : "Share Dana pump logs"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Partajează jurnalele pompei Dana"
+            "state" : "new",
+            "value" : "Share Dana pump logs"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Поделитесь журналом Насос Dana"
+            "value" : "Поделиться логами Dana"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zdieľanie protokolov čerpadla Dana"
+            "value" : "Zdielať logy pumpy Dana"
           }
         },
         "sv" : {
@@ -19091,9 +23965,21 @@
             "value" : "Dana pompa kayıtlarını paylaşın"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Поділіться журналом помпи Dana"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Chia sẻ nhật ký bơm Dana"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Share Dana pump logs"
           }
         },
@@ -19112,12 +23998,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "يجب عرض الوقت في 12 ساعة أو 24 ساعة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Má se čas zobrazovat ve 12h nebo 24h"
           }
         },
         "da" : {
@@ -19152,25 +24032,25 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Should time be display in 12h or 24h"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Should time be display in 12h or 24h"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'orario dovrebbe essere visualizzato in 12 o 24 ore?"
+            "value" : "L'ora deve essere visualizzata in 12 o 24 ore"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "時刻は12時間表示か24時間表示か"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Should time be display in 12h or 24h"
           }
         },
@@ -19186,28 +24066,28 @@
             "value" : "Czy czas powinien być wyświetlany w trybie 12-godzinnym czy 24-godzinnym?"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "A hora deve ser exibida em 12h ou 24h?"
+            "state" : "new",
+            "value" : "Should time be display in 12h or 24h"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Timpul trebuie afișat în 12h sau 24h"
+            "state" : "new",
+            "value" : "Should time be display in 12h or 24h"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Время должно отображаться в 12 или 24 часах"
+            "value" : "Показывать время в 12ч или 24ч формате"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Či sa má čas zobrazovať v 12h alebo 24h"
+            "value" : "12 hodinový alebo 24 hodinový režim zobrazovania času"
           }
         },
         "sv" : {
@@ -19222,9 +24102,21 @@
             "value" : "Zaman 12 saat mi yoksa 24 saat olarak mı gösterilmeli"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Час має відображатися через 12 або 24 години"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Thời gian được hiển thị 12h hoặc 24h"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Should time be display in 12h or 24h"
           }
         },
@@ -19243,12 +24135,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "فقدان الإشارة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ztráta signálu"
           }
         },
         "da" : {
@@ -19271,8 +24157,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Signaalin menetys"
+            "state" : "new",
+            "value" : "Signal Loss"
           }
         },
         "fr" : {
@@ -19283,26 +24169,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Signal Loss"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Signal Loss"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Perdita segnale"
+            "value" : "Perdita Di Segnale"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "信号損失"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Signal Tap"
+            "value" : "Signaltap"
           }
         },
         "nl" : {
@@ -19313,20 +24199,20 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Utrata sygnału"
+            "state" : "new",
+            "value" : "Signal Loss"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Signal Loss"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Perda de sinal"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pierdere de semnal"
+            "state" : "new",
+            "value" : "Signal Loss"
           }
         },
         "ru" : {
@@ -19353,16 +24239,28 @@
             "value" : "Sinyal Kaybı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Втрата сигналу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Mất tín hiệu"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Signal Loss"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "信号丢失"
+            "state" : "new",
+            "value" : "Signal Loss"
           }
         }
       }
@@ -19374,12 +24272,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الصوت"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zvuk"
           }
         },
         "da" : {
@@ -19414,7 +24306,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Sound"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Sound"
           }
         },
@@ -19424,15 +24322,9 @@
             "value" : "Suono"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "サウンド"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Sound"
           }
         },
@@ -19448,16 +24340,16 @@
             "value" : "Dźwięk"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Som"
+            "state" : "new",
+            "value" : "Sound"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sunet"
+            "state" : "new",
+            "value" : "Sound"
           }
         },
         "ru" : {
@@ -19484,9 +24376,21 @@
             "value" : "Ses"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Звук"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Âm thanh"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Sound"
           }
         },
@@ -19505,12 +24409,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الحالة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stav"
           }
         },
         "da" : {
@@ -19545,7 +24443,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Status"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Status"
           }
         },
@@ -19555,13 +24459,7 @@
             "value" : "Stato"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "ステータス"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Status"
@@ -19575,26 +24473,20 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Status"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Status"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Status"
-          }
-        },
-        "pt-BR" : {
-          "stringUnit" : {
-            "state" : "translated",
             "value" : "Estado"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Stare"
           }
         },
         "ru" : {
@@ -19621,10 +24513,22 @@
             "value" : "Durum"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Статус"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tình trạng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Status"
           }
         },
         "zh-Hans" : {
@@ -19648,7 +24552,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Trin 1: Klargør kanylen"
+            "value" : "Trin 1: Spæd kanylen"
           }
         },
         "de" : {
@@ -19683,7 +24587,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Step 1: Prime cannula"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Step 1: Prime cannula"
           }
         },
@@ -19693,7 +24603,7 @@
             "value" : "Fase 1: adescare la cannula"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trinn 1: Føringskanyle"
@@ -19711,16 +24621,22 @@
             "value" : "Krok 1: Zalanie kaniuli"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Step 1: Prime cannula"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etapa 1: Preparar a cânula"
+            "state" : "new",
+            "value" : "Step 1: Prime cannula"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Шаг 1: заправка канюли"
+            "value" : "Шаг 1: Заправка канюли"
           }
         },
         "sk" : {
@@ -19741,9 +24657,21 @@
             "value" : "Adım 1: Kanülü hazırlayın"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Крок 1: Заправте Канюлю"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Bước 1: Prime cannula"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Step 1: Prime cannula"
           }
         },
@@ -19767,7 +24695,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Trin 1: Indstil reservoirets niveau"
+            "value" : "Trin 1: Indstil reservoirniveau"
           }
         },
         "de" : {
@@ -19796,7 +24724,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Step 1: Set reservoir level"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Step 1: Set reservoir level"
           }
         },
@@ -19806,7 +24740,7 @@
             "value" : "Fase 1: Impostazione del livello del serbatoio"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trinn 1: Angi reservoarnivå"
@@ -19824,22 +24758,28 @@
             "value" : "Krok 1: Ustawienie poziomu zbiornika"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Step 1: Set reservoir level"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etapa 1: Definir o nível do reservatório"
+            "state" : "new",
+            "value" : "Step 1: Set reservoir level"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Шаг 1: Установите уровень резервуара"
+            "value" : "Шаг 1: Задайте уровень в резервуаре"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Krok 1: Nastavenie hladiny v nádrži"
+            "value" : "Krok 1: Nastavenie objemu v zásobníku"
           }
         },
         "sv" : {
@@ -19854,9 +24794,21 @@
             "value" : "Adım 1: Rezervuar seviyesini ayarlayın"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Крок 1: Встановіть рівень у Резервуарі"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Bước 1: Đặt mức Reservoir"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Step 1: Set reservoir level"
           }
         },
@@ -19880,7 +24832,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Trin 2: Indstil mængden af tube-refill"
+            "value" : "Trin 2: Indstil tubegenopfyldningsmængde"
           }
         },
         "de" : {
@@ -19909,7 +24861,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Step 2: Set tube refill amount"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Step 2: Set tube refill amount"
           }
         },
@@ -19919,7 +24877,7 @@
             "value" : "Fase 2: Impostazione della quantità di ricarica del tubo"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trinn 2: Påfyllingsmengde til tube"
@@ -19937,16 +24895,22 @@
             "value" : "Krok 2: Ustawienie ilości napełnienia tuby"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Step 2: Set tube refill amount"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Etapa 2: Defina a quantidade de recarga do tubo"
+            "state" : "new",
+            "value" : "Step 2: Set tube refill amount"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Шаг 2: Установите количество пополнения тюбика"
+            "value" : "Шаг 2: Задайте объем заполнения трубки"
           }
         },
         "sk" : {
@@ -19967,9 +24931,21 @@
             "value" : "Adım 2: Tüp dolum miktarını ayarlayın"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Крок 2: Встановіть кількість поповнення тюбика"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Bước 2: Đặt lượng ống nạp lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Step 2: Set tube refill amount"
           }
         },
@@ -19983,6 +24959,132 @@
     },
     "Stop bolus" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stoppa bolus"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Stop bolus"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19998,12 +25100,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "وقف درجة الحرارة القاعدية"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zastavení bazální teploty"
           }
         },
         "da" : {
@@ -20038,7 +25134,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Stop temp basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Stop temp basal"
           }
         },
@@ -20048,15 +25150,9 @@
             "value" : "Interruzione della temperatura basale"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "基礎体温停止"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Stop temp basal"
           }
         },
@@ -20072,28 +25168,28 @@
             "value" : "Zatrzymanie temperatury podstawowej"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Parar a temperatura basal"
+            "state" : "new",
+            "value" : "Stop temp basal"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opriți temp bazal"
+            "state" : "new",
+            "value" : "Stop temp basal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Прекратите базальную температуру"
+            "value" : "Остановить временную базальную скорость"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zastavenie bazálnej teploty"
+            "value" : "Zastaviť dočasnú dávku bazálu"
           }
         },
         "sv" : {
@@ -20108,9 +25204,21 @@
             "value" : "Bazal sıcaklığı durdur"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Зупинити тимчасову базу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Tạm dừng liều temp basal"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Stop temp basal"
           }
         },
@@ -20127,26 +25235,20 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "تعليق"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pozastavit"
+            "state" : "new",
+            "value" : "Suspend"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Suspendere"
+            "value" : "Suspender"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "aussetzen."
+            "value" : "Unterbrechen"
           }
         },
         "es" : {
@@ -20157,8 +25259,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Keskeytä"
+            "state" : "new",
+            "value" : "Suspend"
           }
         },
         "fr" : {
@@ -20169,8 +25271,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Suspend"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Felfüggesztés"
           }
         },
         "it" : {
@@ -20179,46 +25287,40 @@
             "value" : "Sospendi"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "サスペンド"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suspendere"
+            "value" : "Pause leveranse"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "opschorten"
+            "value" : "Onderbreek"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wstrzymano"
+            "state" : "new",
+            "value" : "Suspend"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Suspend"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suspender"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suspendați"
+            "state" : "new",
+            "value" : "Suspend"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Приостановка"
+            "value" : "Остановка"
           }
         },
         "sk" : {
@@ -20230,7 +25332,7 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Avvakta"
+            "value" : "Pausa"
           }
         },
         "tr" : {
@@ -20239,9 +25341,21 @@
             "value" : "Askıya al"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Призупинити"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã tạm dừng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Suspend"
           }
         },
@@ -20262,16 +25376,10 @@
             "value" : "تعليق التسليم"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pozastavení dodávky"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Suspender levering"
+            "value" : "Suspendér levering"
           }
         },
         "de" : {
@@ -20300,7 +25408,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Suspend delivery"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Suspend delivery"
           }
         },
@@ -20310,15 +25424,9 @@
             "value" : "Sospendere la consegna"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "配送の一時停止"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Suspend delivery"
           }
         },
@@ -20334,28 +25442,28 @@
             "value" : "Zawieszenie dostawy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suspender a entrega"
+            "state" : "new",
+            "value" : "Suspend delivery"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Suspendarea livrării"
+            "state" : "new",
+            "value" : "Suspend delivery"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Приостановить доставку"
+            "value" : "Приостановить подачу"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pozastavenie dodávky"
+            "value" : "Pozastaviť dávkovanie"
           }
         },
         "sv" : {
@@ -20370,9 +25478,21 @@
             "value" : "Teslimatı askıya alın"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Призупинити подачу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Tạm ngưng liều insulin"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Suspend delivery"
           }
         },
@@ -20393,16 +25513,10 @@
             "value" : "مزامنة بيانات المضخة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Synchronizace dat čerpadla"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synkroniser pumpedata"
+            "value" : "Synk pumpedata"
           }
         },
         "de" : {
@@ -20431,7 +25545,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Sync pump data"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Sync pump data"
           }
         },
@@ -20441,15 +25561,9 @@
             "value" : "Sincronizzazione dei dati della pompa"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプデータの同期"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Sync pump data"
           }
         },
@@ -20465,28 +25579,28 @@
             "value" : "Synchronizacja danych pompy"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizar dados da bomba"
+            "state" : "new",
+            "value" : "Sync pump data"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sincronizarea datelor pompei"
+            "state" : "new",
+            "value" : "Sync pump data"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Синхронизация данных насоса"
+            "value" : "Синхронизация данных помпы"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synchronizácia údajov čerpadla"
+            "value" : "Synchronizovať údaje pumpy"
           }
         },
         "sv" : {
@@ -20501,9 +25615,21 @@
             "value" : "Pompa verilerini senkronize et"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Синхронізація даних Помпи"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đồng bộ dữ liệu bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Sync pump data"
           }
         },
@@ -20517,10 +25643,130 @@
     },
     "temp basal" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basale temporanea"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "temporär basal"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "temp basal"
           }
         },
         "zh-Hans" : {
@@ -20536,68 +25782,62 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "درجة الحرارة القاعدية"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Temp Basal"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Temp Basal"
+            "value" : "Midlertidig Basal"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Temp. Basal"
+            "value" : "Temporäre Basalrate"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Temp Basal"
+            "value" : "Insulina basal temporal"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Lämpötila Peruslämpötila"
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Temp Basal"
+            "value" : "Basal Temp."
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Temp Basal"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Temperatura basale"
+            "value" : "Basale temporanea"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "基礎温度"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Temp Basal"
+            "value" : "Midlertidig basal"
           }
         },
         "nl" : {
@@ -20608,44 +25848,50 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Temp. podstawowa"
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Temp. Basal"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Temperatură bazală"
+            "state" : "new",
+            "value" : "Temp Basal"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Базальная температура"
+            "value" : "Врем. базал"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Temp Basal"
+            "value" : "Dočasný bazál"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Temp Basal"
+            "value" : "Temporär basal"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sıcaklık Bazal"
+            "value" : "Geçici Bazal Oranı"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тимчасовий  Базал"
           }
         },
         "vi" : {
@@ -20654,10 +25900,16 @@
             "value" : "Temp Basal"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Temp Basal"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "基础温度"
+            "value" : "临时基础率"
           }
         }
       }
@@ -20671,16 +25923,10 @@
             "value" : "تدعم مضخات دانا سرعات توصيل مختلفة. يمكنك إعدادها هنا"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Čerpadla Dana podporují různé rychlosti dodávky. Nastavit je můžete zde"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dana-pumperne understøtter forskellige leveringshastigheder. Du kan sætte det op her"
+            "value" : "Dana-pumperne understøtter forskellige leveringshastigheder. Disse kan opsættes her"
           }
         },
         "de" : {
@@ -20709,7 +25955,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "The Dana pumps support different delivery speeds. You can set it up here"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The Dana pumps support different delivery speeds. You can set it up here"
           }
         },
@@ -20719,15 +25971,9 @@
             "value" : "Le pompe Dana supportano diverse velocità di erogazione. È possibile impostarle qui"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Danaポンプは、異なる吐出速度に対応しています。ここで設定できる"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "The Dana pumps support different delivery speeds. You can set it up here"
           }
         },
@@ -20743,28 +25989,28 @@
             "value" : "Pompy Dana obsługują różne prędkości podawania. Można je skonfigurować tutaj"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "As bombas Dana suportam diferentes velocidades de entrega. Você pode configurá-la aqui"
+            "state" : "new",
+            "value" : "The Dana pumps support different delivery speeds. You can set it up here"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pompele Dana suportă diferite viteze de livrare. O puteți configura aici"
+            "state" : "new",
+            "value" : "The Dana pumps support different delivery speeds. You can set it up here"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Насосы Dana поддерживают разные скорости подачи. Вы можете настроить его здесь"
+            "value" : "Помпы Dana поддерживают разные скорости подачи. Вы можете настроить это здесь"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Čerpadlá Dana podporujú rôzne rýchlosti dodávky. Nastaviť ju môžete tu"
+            "value" : "Pumpy Dana podporujú rôzne rýchlosti podania dávky 1 jednotky inzulínu. Môžete si ich nastaviť tu"
           }
         },
         "sv" : {
@@ -20779,9 +26025,21 @@
             "value" : "Dana pompaları farklı dağıtım hızlarını destekler. Buradan ayarlayabilirsiniz"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помпи Dana підтримують різні швидкості подачи. Ви можете налаштувати їх тут"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Máy bơm Dana hỗ trợ nhiều tốc độ phân phối khác nhau. Bạn có thể thiết lập ở đây"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The Dana pumps support different delivery speeds. You can set it up here"
           }
         },
@@ -20802,16 +26060,10 @@
             "value" : "تدعم مضخات دانا سرعات توصيل مختلفة. يمكنك إعدادها هنا، ولكن أيضاً في قائمة الإعدادات"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Čerpadla Dana podporují různé rychlosti dodávky. Můžete je nastavit zde, ale také v nabídce nastavení."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dana-pumperne understøtter forskellige leveringshastigheder. Du kan indstille det her, men også i indstillingsmenuen"
+            "value" : "Dana-pumperne understøtter forskellige leveringshastigheder, hvilket kan indstilles her eller via indstillingsmenuen"
           }
         },
         "de" : {
@@ -20840,7 +26092,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "The Dana pumps support different delivery speeds. You can set it up here, but also in the settings menu"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The Dana pumps support different delivery speeds. You can set it up here, but also in the settings menu"
           }
         },
@@ -20850,15 +26108,9 @@
             "value" : "Le pompe Dana supportano diverse velocità di erogazione. È possibile impostarla qui, ma anche nel menu delle impostazioni."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Danaポンプは異なる吐出速度に対応しています。ここで設定できますが、設定メニューでも設定できます。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "The Dana pumps support different delivery speeds. You can set it up here, but also in the settings menu"
           }
         },
@@ -20874,28 +26126,28 @@
             "value" : "Pompy Dana obsługują różne prędkości podawania. Można je skonfigurować tutaj, ale także w menu ustawień"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "As bombas Dana suportam diferentes velocidades de entrega. Você pode configurá-las aqui, mas também no menu de configurações"
+            "state" : "new",
+            "value" : "The Dana pumps support different delivery speeds. You can set it up here, but also in the settings menu"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pompele Dana acceptă diferite viteze de livrare. Puteți să le configurați aici, dar și în meniul de setări"
+            "state" : "new",
+            "value" : "The Dana pumps support different delivery speeds. You can set it up here, but also in the settings menu"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Насосы Dana поддерживают разные скорости подачи. Настроить их можно здесь, а также в меню настроек"
+            "value" : "Помпы Dana поддерживают разные скорости подачи. Настроить их можно здесь, а также в меню настроек"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Čerpadlá Dana podporujú rôzne rýchlosti dodávky. Môžete ju nastaviť tu, ale aj v ponuke nastavení"
+            "value" : "Pumpy Dana podporujú rôzne rýchlosti podania dávky 1 jednotky inzulínu. Môžete ju nastaviť tu, ale aj v ponuke nastavení pumpy"
           }
         },
         "sv" : {
@@ -20910,9 +26162,21 @@
             "value" : "Dana pompaları farklı dağıtım hızlarını destekler. Bunu buradan ve aynı zamanda ayarlar menüsünden ayarlayabilirsiniz"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помпи Dana підтримують різні швидкості доставки. Ви можете налаштувати це тут, а також у меню налаштувань"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Máy bơm Dana hỗ trợ nhiều tốc độ phân phối khác nhau. Bạn có thể thiết lập ở đây, nhưng cũng có thể trong menu cài đặt"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The Dana pumps support different delivery speeds. You can set it up here, but also in the settings menu"
           }
         },
@@ -20933,16 +26197,10 @@
             "value" : "تم تعليق توصيل الأنسولين. فشل الإجراء"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Podávání inzulínu bylo pozastaveno. Akce se nezdařila"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tilførslen af insulin er blevet suspenderet. Handling mislykkedes"
+            "value" : "Insulinleveringen er blevet suspenderet. Handling mislykkedes"
           }
         },
         "de" : {
@@ -20971,7 +26229,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "The insulin delivery has been suspend. Action failed"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The insulin delivery has been suspend. Action failed"
           }
         },
@@ -20981,15 +26245,9 @@
             "value" : "La somministrazione di insulina è stata sospesa. Azione fallita"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "インスリン投与が中断されました。処置失敗"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "The insulin delivery has been suspend. Action failed"
           }
         },
@@ -21005,22 +26263,22 @@
             "value" : "Dostarczanie insuliny zostało wstrzymane. Działanie nie powiodło się"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "O fornecimento de insulina foi suspenso. A ação falhou"
+            "state" : "new",
+            "value" : "The insulin delivery has been suspend. Action failed"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Administrarea insulinei a fost suspendată. Acțiune eșuată"
+            "state" : "new",
+            "value" : "The insulin delivery has been suspend. Action failed"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Доставка инсулина была приостановлена. Действие не удалось"
+            "value" : "Подача инсулина была приостановлена. Действие не удалось"
           }
         },
         "sk" : {
@@ -21041,9 +26299,21 @@
             "value" : "İnsülin teslimatı askıya alındı. Eylem başarısız"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Подачу інсуліну призупинено. Не вдалося виконати дію"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Việc cung cấp insulin đã bị tạm dừng. Hành động không thành công"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The insulin delivery has been suspend. Action failed"
           }
         },
@@ -21062,12 +26332,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "تم الوصول إلى الحد الأقصى للجرعة القصوى. يُرجى تجربة كمية أقل أو زيادة الحد الأقصى"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Je dosaženo maximálního limitu bolusu. Vyzkoušejte nižší množství nebo zvyšte limit"
           }
         },
         "da" : {
@@ -21102,7 +26366,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "The max bolus limit is reached. Please try a lower amount or increase the limit"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The max bolus limit is reached. Please try a lower amount or increase the limit"
           }
         },
@@ -21112,15 +26382,9 @@
             "value" : "Il limite massimo di bolo è stato raggiunto. Provare con una quantità inferiore o aumentare il limite"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ボーラスの上限値に達しています。量を減らすか、上限を増やしてください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "The max bolus limit is reached. Please try a lower amount or increase the limit"
           }
         },
@@ -21136,22 +26400,22 @@
             "value" : "Osiągnięto maksymalny limit bolusa. Spróbuj użyć niższej dawki lub zwiększ limit"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "O limite máximo de bolus foi atingido. Tente uma quantidade menor ou aumente o limite"
+            "state" : "new",
+            "value" : "The max bolus limit is reached. Please try a lower amount or increase the limit"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limita maximă de bolus a fost atinsă. Vă rugăm să încercați o cantitate mai mică sau să măriți limita"
+            "state" : "new",
+            "value" : "The max bolus limit is reached. Please try a lower amount or increase the limit"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Максимальный лимит болюса достигнут. Пожалуйста, попробуйте меньшее количество или увеличьте лимит"
+            "value" : "Лимит болюса достигнут. Попробуйте задать меньшее количество или увеличьте лимит"
           }
         },
         "sk" : {
@@ -21172,9 +26436,21 @@
             "value" : "Maksimum bolus limitine ulaşıldı. Lütfen daha düşük bir miktar deneyin veya limiti artırın"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Досягнуто максимального ліміту болюсу. Спробуйте зменшити суму або збільште ліміт"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã đạt đến giới hạn bolus tối đa. Vui lòng thử lượng thấp hơn hoặc tăng giới hạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The max bolus limit is reached. Please try a lower amount or increase the limit"
           }
         },
@@ -21195,16 +26471,10 @@
             "value" : "تم الوصول إلى الحد الأقصى اليومي للأنسولين. يُرجى تجربة كمية أقل أو زيادة الحد الأقصى"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Je dosažen maximální denní limit inzulínu. Vyzkoušejte nižší množství nebo zvyšte limit"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Den maksimale daglige insulin-grænse er nået. Prøv en lavere mængde, eller øg grænsen."
+            "value" : "Den maksimale daglige insulingrænse er nået. Prøv en lavere mængde, eller øg grænsen"
           }
         },
         "de" : {
@@ -21233,7 +26503,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "The max daily insulin limit is reached. Please try a lower amount or increase the limit"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The max daily insulin limit is reached. Please try a lower amount or increase the limit"
           }
         },
@@ -21243,15 +26519,9 @@
             "value" : "Il limite massimo di insulina giornaliero è stato raggiunto. Provare con una quantità inferiore o aumentare il limite"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "1日のインスリン量が上限に達しています。もう少し量を減らすか、上限を増やしてください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "The max daily insulin limit is reached. Please try a lower amount or increase the limit"
           }
         },
@@ -21267,22 +26537,22 @@
             "value" : "Osiągnięto maksymalny dzienny limit insuliny. Spróbuj niższej dawki lub zwiększ limit"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "O limite máximo diário de insulina foi atingido. Tente uma quantidade menor ou aumente o limite"
+            "state" : "new",
+            "value" : "The max daily insulin limit is reached. Please try a lower amount or increase the limit"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limita maximă zilnică de insulină a fost atinsă. Vă rugăm să încercați o cantitate mai mică sau să măriți limita"
+            "state" : "new",
+            "value" : "The max daily insulin limit is reached. Please try a lower amount or increase the limit"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Максимальный суточный лимит инсулина достигнут. Пожалуйста, попробуйте использовать меньшее количество или увеличьте лимит"
+            "value" : "Суточный лимит инсулина достигнут. Попробуйте задать меньшее количество или увеличьте лимит"
           }
         },
         "sk" : {
@@ -21303,9 +26573,21 @@
             "value" : "Maksimum günlük insülin limitine ulaşıldı. Lütfen daha düşük bir miktar deneyin veya limiti artırın"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Досягнуто максимального добового ліміту інсуліну. Спробуйте зменшити суму або збільште ліміт"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã đạt đến giới hạn insulin tối đa hàng ngày. Vui lòng thử lượng thấp hơn hoặc tăng giới hạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The max daily insulin limit is reached. Please try a lower amount or increase the limit"
           }
         },
@@ -21324,12 +26606,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "اكتشفت المضخة وجود مشكلة في عمودها. يرجى إزالة الخزان وفحص كل شيء والمحاولة مرة أخرى"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Čerpadlo zjistilo problém s řetězem. Vyjměte nádržku, vše zkontrolujte a zkuste to znovu."
           }
         },
         "da" : {
@@ -21364,7 +26640,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "The pump has detected an issue with its chaft. Please remove the reservoir, check everything and try again"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The pump has detected an issue with its chaft. Please remove the reservoir, check everything and try again"
           }
         },
@@ -21374,15 +26656,9 @@
             "value" : "La pompa ha rilevato un problema con il suo albero. Rimuovere il serbatoio, controllare tutto e riprovare."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ポンプがシャフトの問題を検出しました。リザーバを取り外し、すべてを確認してから再度お試しください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "The pump has detected an issue with its chaft. Please remove the reservoir, check everything and try again"
           }
         },
@@ -21398,22 +26674,22 @@
             "value" : "Pompa wykryła problem z wałkiem. Wyjmij zbiornik, sprawdź wszystko i spróbuj ponownie"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "A bomba detectou um problema em sua haste. Remova o reservatório, verifique tudo e tente novamente"
+            "state" : "new",
+            "value" : "The pump has detected an issue with its chaft. Please remove the reservoir, check everything and try again"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pompa a detectat o problemă cu șaiba sa. Vă rugăm să scoateți rezervorul, să verificați totul și să încercați din nou"
+            "state" : "new",
+            "value" : "The pump has detected an issue with its chaft. Please remove the reservoir, check everything and try again"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Насос обнаружил проблему с валом. Пожалуйста, снимите резервуар, проверьте все и повторите попытку"
+            "value" : "Помпа обнаружила проблему с валом. Пожалуйста, снимите резервуар, проверьте все и повторите попытку"
           }
         },
         "sk" : {
@@ -21434,9 +26710,21 @@
             "value" : "Pompa, şaftında bir sorun tespit etti. Lütfen rezervuarı çıkarın, her şeyi kontrol edin ve tekrar deneyin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Помпа виявивла проблему з валом. Вийміть резервуар, перевірте все та повторіть спробу"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Máy bơm đã phát hiện ra sự cố với chaft của nó. Vui lòng tháo bình chứa, kiểm tra mọi thứ và thử lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The pump has detected an issue with its chaft. Please remove the reservoir, check everything and try again"
           }
         },
@@ -21451,6 +26739,132 @@
     "The pump reminds you when the amount of insulin in the pump reaches this level" : {
       "comment" : "Description for low reservoir reminder",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "it" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "nb-NO" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpen kommer att påminna dig när mängd insulin i pumpen når denna nivå"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21465,103 +26879,97 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الوقت على مضختك مختلف عن الوقت الحالي. هل تريد تحديث الوقت على مضختك إلى الوقت الحالي؟"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Čas na čerpadle se liší od aktuálního času. Chcete aktualizovat čas na čerpadle na aktuální čas?"
+            "value" : "الوقت في مضختك مختلف عن الوقت الحالي. هل ترغب في تحديث الوقت في مضختك ليتوافق مع الوقت الحالي؟"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tiden på din pumpe er forskellig fra den aktuelle tid. Vil du opdatere tiden på din pumpe til den aktuelle tid?"
+            "value" : "Tiden på din pumpe er forskellig fra den aktuelle tid. Vil du opdatere tiden på din pumpe til det aktuelle tidspunkt?"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Die Zeit auf Ihrer Pumpe weicht von der aktuellen Zeit ab. Möchten Sie die Zeit auf Ihrer Pumpe auf die aktuelle Zeit aktualisieren?"
+            "value" : "Die Zeit Ihrer Pumpe unterscheidet sich von der aktuellen Zeit. Möchten Sie die Pumpenzeit auf die aktuelle Zeit aktualisieren?"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La hora de la bomba es diferente de la hora actual. Desea actualizar la hora de su bomba a la hora actual?"
+            "value" : "La hora de la bomba es diferente de la hora actual. ¿Desea actualizar la hora de su bomba a la hora actual?"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pumppusi kellonaika poikkeaa nykyisestä kellonajasta. Haluatko päivittää pumppusi ajan nykyiseen aikaan?"
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'heure de votre pompe est différente de l'heure actuelle. Voulez-vous mettre à jour l'heure de votre pompe pour qu'elle corresponde à l'heure actuelle ?"
+            "value" : "L'heure de votre pompe est différente de l'heure actuelle. Voulez vous mettre à jour l'heure de votre pompe avec l'heure actuelle ?"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'orario indicato sulla pompa è diverso dall'orario attuale. Vuoi aggiornare l'orario indicato sulla pompa con l'orario attuale?"
+            "value" : "L'ora sul microinfusore è diversa dall'ora corrente. Vuoi aggiornare l'ora del microinfusore all'ora corrente?"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ポンプの時刻が現在時刻と異なっています。ポンプの時刻を現在時刻に更新しますか？"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Klokken på pumpen er forskjellig fra gjeldende tid. Vil du oppdatere tiden på pumpen til gjeldende tid?"
+            "value" : "Tiden det tar på pumpen er forskjellig fra nåværende tidspunkt. Ønsker du å oppdatere tidspunktet på pumpen til nåværende tidspunkt?"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "De tijd op je pomp is anders dan de huidige tijd. Wil je de tijd op je pomp bijwerken naar de huidige tijd?"
+            "value" : "De pomptijd is anders dan de huidige tijd. Wil je de tijd van je pomp updaten naar de huidige tijd?"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Czas na pompie różni się od aktualnego. Czy chcesz zaktualizować czas na pompie?"
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "A hora em sua bomba é diferente da hora atual. Deseja atualizar a hora em sua bomba para a hora atual?"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ora de pe pompă este diferită de ora curentă. Puteți revizui ora pompei și să o sincronizați cu ora curentă în meniul setări."
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Время на вашей помпе отличается от текущего времени. Вы хотите обновить время на вашей помпе на текущее?"
+            "value" : "Время на помпе отличается от текущего времени. Обновить время на помпе до текущего времени?"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Čas na vašej pumpe sa líši od aktuálneho času. Chcete aktualizovať čas na čerpadle na aktuálny čas?"
+            "value" : "Čas na Vašej pumpe sa líši od aktuálneho času. Chcete aktualizovať čas na vašej pumpe na aktuálny čas?"
           }
         },
         "sv" : {
@@ -21573,19 +26981,31 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pompanızdaki saat geçerli saatten farklı. Pompanızdaki saati geçerli saate güncellemek istiyor musunuz?"
+            "value" : "Pompanızdaki saat, mevcut saatten farklı. Pompanızdaki saati şu anki saate güncellemek ister misiniz?"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Час на вашій помпі відрізняється від поточного часу. Хочете оновити час на помпі до поточного?"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Thời gian trên máy bơm của bạn khác với thời gian hiện tại. Bạn có muốn cập nhật thời gian trên máy bơm của mình đến thời điểm hiện tại không?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "泵上的时间与当前时间不同。您想将泵上的时间更新为当前时间吗？"
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         }
       }
@@ -21595,128 +27015,134 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "يختلف الوقت في مضختك عن الوقت الحالي. يتحكم وقت مضختك في إعدادات العلاج المجدول الخاص بك. قم بالتمرير لأسفل إلى صف وقت المضخة لمراجعة فرق الوقت وتهيئة المضخة الخاصة بك."
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Čas na čerpadle se liší od aktuálního času. Čas vaší pumpy řídí nastavení plánované terapie. Přejděte dolů na řádek Čas pumpy a zkontrolujte časový rozdíl a nastavte svou pumpu."
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tiden på din pumpe er forskellig fra den aktuelle tid. Din pumpes tid styrer dine planlagte behandlingsindstillinger. Rul ned til rækken Pumpetid for at se tidsforskellen og konfigurere din pumpe."
+            "value" : "Tiden på din pumpe er forskellig fra den aktuelle tid. Din pumpes tid styrer dine planlagte behandlingsindstillinger. Gå til Pumpetid for at gennemgå tidsforskellen og konfigurere din pumpe."
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Die Uhrzeit auf Ihrer Pumpe unterscheidet sich von der aktuellen Uhrzeit. Die Zeit Ihrer Pumpe steuert Ihre geplanten Therapieeinstellungen. Blättern Sie nach unten zur Zeile Pumpenzeit, um den Zeitunterschied zu überprüfen und Ihre Pumpe zu konfigurieren."
+            "value" : "Die Uhrzeit der Pumpe weicht von der aktuellen Uhrzeit ab. Die Zeit der Pumpe steuert die geplanten Therapieeinstellungen. Scrolle nach unten zur Zeile Pumpenzeit, um den Zeitunterschied zu überprüfen und die Pumpe zu konfigurieren."
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La hora de su bomba es diferente de la hora actual. La hora de su bomba controla los ajustes programados de su terapia. Desplácese hacia abajo hasta la fila Hora de la bomba para revisar la diferencia horaria y configurar su bomba."
+            "value" : "La hora de su bomba es diferente de la hora actual. La hora de su bomba controla los ajustes programados de su terapia. Desplácese hacia abajo hasta la fila que muestra la Hora de la Bomba para revisar la diferencia horaria y configurar su bomba."
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pumppusi kellonaika poikkeaa nykyisestä kellonajasta. Pumpun aika ohjaa ajastettuja hoitoasetuksia. Selaa alaspäin Pumpun aika -riville, jotta voit tarkistaa aikaeron ja määrittää pumpun asetukset."
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'heure de votre pompe est différente de l'heure actuelle. L'heure de votre pompe contrôle les paramètres de votre thérapie programmée. Faites défiler vers le bas jusqu'à la ligne Heure de la pompe pour consulter le décalage horaire et configurer votre pompe."
+            "value" : "L'heure de votre pompe est différente de l'heure actuelle. L'heure de votre pompe contrôle les paramètres de votre traitement. Faites défiler jusqu'à la ligne Heure de Pompe pour vérifier le décalage de l'heure et configurer votre pompe."
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "השעה במשאבה שלך שונה מהשעה הנוכחית. הגדרות הטיפול נקבעות לפי השעה במשאבה.  יש לבדוק את הפרשי הזמן ולעדכן את השעה במשאבה."
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'ora del microinfusore è diversa dall'ora corrente. L'ora del microinfusore controlla le impostazioni della terapia programmata. Scorrere la riga dell'ora del microinfusore per verificare la differenza di orario e configurare il microinfusore."
+            "value" : "L'orario impostato nel microinfusore è diverso dall'orario corrente. L'orario del microinfusore detta e controlla le impostazioni della terapia programmata e va corretto: Nella lista degli 'orari del microinfusore verificare la differenza di orario e configurare correttamente il microinfusore."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ポンプの時刻は現在時刻とは異なります。ポンプの時刻はスケジュールされた治療設定を制御します。ポンプ時刻の行までスクロールして、時差を確認し、ポンプを設定してください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
+            "value" : "Klokken på pumpen er forskjellig fra gjeldende tid. Pumpens tid styrer dine planlagte behandlingsinnstillinger. Rull ned til Pumpetid-raden for å se tidsforskjellen og konfigurere pumpen."
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "De tijd op je pomp verschilt van de huidige tijd. De tijd op je pomp bepaalt je geplande therapie-instellingen. Scroll naar beneden naar de rij Pomptijd om het tijdsverschil te bekijken en je pomp te configureren."
+            "value" : "De tijd op je pomp is anders dan de huidige tijd. De tijd van je pomp bepaalt je geplande therapieinstellingen. Scroll omlaag naar de Pomptijd om het tijdsverschil te bekijken en de pomp te configureren."
           }
         },
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Godzina na pompie różni się od aktualnej godziny. Czas pompy steruje ustawieniami zaplanowanej terapii. Przewiń w dół do wiersza Pump Time (Czas pompy), aby sprawdzić różnicę czasu i skonfigurować pompę."
+            "value" : "Czas na pompie różni się od aktualnego czasu. Czas pompy steruje ustawieniami zaplanowanej terapii. Przewiń w dół do wiersza Czas pompy, aby przejrzeć różnicę czasu i skonfigurować pompę."
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "A hora em sua bomba é diferente da hora atual. A hora da bomba controla as configurações da terapia programada. Role para baixo até a linha Pump Time (Hora da bomba) para revisar a diferença de horário e configurar sua bomba."
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ora de pe pompa dvs. este diferită de ora curentă. Ora pompei dvs. controlează setările terapiei programate. Derulați în jos până la rândul Ora pompei pentru a verifica diferența de oră și pentru a configura pompa."
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Время на вашей помпе отличается от текущего времени. Время на помпе контролирует настройки запланированной терапии. Прокрутите вниз до строки \"Время на помпе\", чтобы просмотреть разницу во времени и настроить свою помпу."
+            "value" : "Время на помпе отличается от текущего времени. Время вашей помпы контролирует ваши запланированные настройки терапии. Прокрутите вниз до строки времени помпы, чтобы просмотреть разницу во времени и настроить помпу."
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Čas na vašej pumpe sa líši od aktuálneho času. Čas vašej pumpy riadi nastavenia plánovanej terapie. Prejdite na riadok Čas na pumpe, aby ste skontrolovali časový rozdiel a nakonfigurovali svoju pumpu."
+            "value" : "Čas na pumpe je iný ako aktuálny čas. Čas pumpy riadi vaše naplánované liečebné nastavenia. Prejdite nadol na riadok Čas pumpy, pozrite si časový rozdiel a nakonfigurujte pumpu."
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tiden på din pump skiljer sig från aktuell tid. Pumpens tid styr dina schemalagda behandlingsinställningar. Scrolla ner till raden Pumptid för att granska tidsskillnaden och konfigurera din pump."
+            "value" : "Tiden på din pump skiljer sig från verklig tid. Pumpens tid styr dina schemalagda terapiinställningar. Bläddra ner till raden Pump Tid för att ändra."
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pompanızdaki saat, geçerli saatten farklıdır. Pompanızın saati programlanmış terapi ayarlarınızı kontrol eder. Saat farkını incelemek ve pompanızı yapılandırmak için Pompa Saati satırına ilerleyin."
+            "value" : "Pompanızdaki saat, geçerli saatten farklı. Pompanızın zamanı, planlanmış tedavi ayarlarınızı kontrol eder. Saat farkını gözden geçirmek ve pompanızı yapılandırmak için Pompa Saati satırına ilerleyin."
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Час на вашому Pod'i відрізняється від поточного часу. Час вашого Podʼу контролює налаштування запланованої терапії. Прокрутіть униз до рядка Час Podʼу, щоб переглянути різницю в часі та налаштувати Pod."
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Thời gian trên máy bơm của bạn khác với thời gian hiện tại. Thời gian của máy bơm sẽ kiểm soát cài đặt trị liệu theo lịch trình của bạn. Cuộn xuống đến Pump Time để xem lại chênh lệch thời gian và cấu hình bơm của bạn."
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "泵上的时间与当前时间不同。泵上的时间控制着您的计划治疗设置。向下滚动到泵时间行，查看时差并配置您的泵。"
+            "state" : "new",
+            "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
           }
         }
       }
@@ -21730,16 +27156,10 @@
             "value" : "لم يكن هناك أي تفاعل مع المضخة لفترة طويلة جداً. إما تعطيل هذه الوظيفة في المضخة أو التفاعل مع المضخة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Příliš dlouho nedocházelo k žádným interakcím s čerpadlem. Buď tuto funkci v čerpadle deaktivujte, nebo s čerpadlem interagujte"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Der har ikke været nogen interaktion med pumpen i for lang tid. Deaktiver enten denne funktion i pumpen, eller interager med pumpen."
+            "value" : "Der har ikke været interaktioner med pumpen i for lang tid. Deaktivér enten denne funktion i pumpen, eller interagér med pumpen"
           }
         },
         "de" : {
@@ -21768,7 +27188,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "There has not been any interactions with the pump for too long. Either disable this function in the pump or interact with the pump"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "There has not been any interactions with the pump for too long. Either disable this function in the pump or interact with the pump"
           }
         },
@@ -21778,15 +27204,9 @@
             "value" : "Non ci sono state interazioni con la pompa per troppo tempo. Disattivare questa funzione nella pompa o interagire con la pompa."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "あまりにも長い間、ポンプとの相互作用がありません。ポンプのこの機能を無効にするか、ポンプと対話するかしてください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "There has not been any interactions with the pump for too long. Either disable this function in the pump or interact with the pump"
           }
         },
@@ -21802,22 +27222,22 @@
             "value" : "Przez zbyt długi czas nie było żadnych interakcji z pompą. Wyłącz tę funkcję w pompie lub wejdź w interakcję z pompą"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Não houve nenhuma interação com a bomba por muito tempo. Desative essa função na bomba ou interaja com ela"
+            "state" : "new",
+            "value" : "There has not been any interactions with the pump for too long. Either disable this function in the pump or interact with the pump"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Nu a existat nicio interacțiune cu pompa de prea mult timp. Fie dezactivați această funcție în pompă, fie interacționați cu pompa"
+            "state" : "new",
+            "value" : "There has not been any interactions with the pump for too long. Either disable this function in the pump or interact with the pump"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Слишком долго не было никаких взаимодействий с насосом. Либо отключите эту функцию в насосе, либо взаимодействуйте с насосом"
+            "value" : "Слишком долго не было никаких взаимодействий с помпой. Либо отключите эту функцию в помпе, либо взаимодействуйте с помпой"
           }
         },
         "sk" : {
@@ -21838,16 +27258,28 @@
             "value" : "Çok uzun süredir pompa ile herhangi bir etkileşim olmamıştır. Ya pompadaki bu işlevi devre dışı bırakın ya da pompa ile etkileşime geçin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Занадто довго не було жодної взаємодії з Помпою. Або вимкніть цю функцію в помпі, або взаємодійте з помпою"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã không có bất kỳ tương tác nào với máy bơm trong thời gian quá dài. Hãy vô hiệu hóa chức năng này trong máy bơm hoặc tương tác với máy bơm"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "There has not been any interactions with the pump for too long. Either disable this function in the pump or interact with the pump"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "长时间未与胰岛素泵进行交互。请在胰岛素泵中禁用此功能，或进行一次操作以恢复交互。"
+            "value" : "太久没有与泵进行任何交互。要么禁用泵中的这一功能，要么与泵进行交互"
           }
         }
       }
@@ -21864,7 +27296,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Denne metode til genopfyldning er kun beregnet til, når pumpen ikke kan give mulighed for at genopfylde reservoiret eller spæde kanylen."
+            "value" : "Denne genopfyldningsmetode er kun til situationer, hvor pumpen ingen mulighed har for at genopfylde reservoiret eller spæde kanylen"
           }
         },
         "de" : {
@@ -21893,7 +27325,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "This method of refilling is only intended for when the pump cannot provide a way to refill the reservoir or prime the cannula"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "This method of refilling is only intended for when the pump cannot provide a way to refill the reservoir or prime the cannula"
           }
         },
@@ -21903,7 +27341,7 @@
             "value" : "Questo metodo di riempimento è previsto solo quando la pompa non può fornire un modo per riempire il serbatoio o adescare la cannula."
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Denne påfyllingsmetoden er kun beregnet for når pumpen ikke kan sikre en måte å fylle reservoaret på eller klargjøre kanyletoppen"
@@ -21918,19 +27356,25 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ta metoda napełniania jest używana wyłącznie w sytuacji, gdy pompa nie jest w stanie zapewnić możliwości ponownego napełnienia zbiornika lub zalania kaniuli."
+            "value" : "Ta metoda uzupełniania jest przeznaczona tylko wtedy, gdy pompa nie może zapewnić możliwości uzupełnienia zbiornika lub zalania kaniuli"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "This method of refilling is only intended for when the pump cannot provide a way to refill the reservoir or prime the cannula"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Esse método de reabastecimento destina-se apenas a quando a bomba não puder fornecer uma maneira de reabastecer o reservatório ou preparar a cânula"
+            "state" : "new",
+            "value" : "This method of refilling is only intended for when the pump cannot provide a way to refill the reservoir or prime the cannula"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Этот способ заправки предназначен только для тех случаев, когда насос не может обеспечить пополнение резервуара или заправки канюли"
+            "value" : "Этот способ заправки предназначен только для тех случаев, когда помпа не может обеспечить заполнение резервуара или заправку канюли"
           }
         },
         "sk" : {
@@ -21951,9 +27395,21 @@
             "value" : "Bu yeniden doldurma yöntemi yalnızca pompanın rezervuarı yeniden doldurmak veya kanülü prime etmek için bir yol sağlayamadığı durumlar için tasarlanmıştır"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Цей спосіб заправлення призначений тільки для тих випадків, коли Помпа не може забезпечити поповнення Резервуара або заправки Канюлі."
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Phương pháp nạp lại này chỉ dành cho trường hợp máy bơm không thể nạp lại bình chứa hoặc mồi ống thông"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "This method of refilling is only intended for when the pump cannot provide a way to refill the reservoir or prime the cannula"
           }
         },
@@ -21971,25 +27427,19 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "تم اكتشاف تغير الوقت"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Zjištěná změna času"
+            "value" : "تم اكتشاف تغيير في الوقت"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tidsændring opdaget"
+            "value" : "Tidsændring registreret"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erkannte Zeitänderung"
+            "value" : "Zeitänderung erkannt"
           }
         },
         "es" : {
@@ -22000,35 +27450,35 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ajan muutos havaittu"
+            "state" : "new",
+            "value" : "Time Change Detected"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Changement d'heure détecté"
+            "value" : "Changement de temps détecté"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Time Change Detected"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Time Change Detected"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rilevato cambio di orario"
+            "value" : "Rilevato Cambio Di Tempo"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "検出された時間変化"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tidsendring oppdaget"
@@ -22037,25 +27487,25 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tijdsverandering gedetecteerd"
+            "value" : "Wijziging in tijd gedetecteerd"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Wykryto zmianę czasu"
+            "state" : "new",
+            "value" : "Time Change Detected"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Time Change Detected"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Mudança de horário detectada"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "S-a detectat schimbarea orei"
+            "state" : "new",
+            "value" : "Time Change Detected"
           }
         },
         "ru" : {
@@ -22073,25 +27523,37 @@
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tidsändring detekterad"
+            "value" : "Tidsjustering upptäckt"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zaman Değişikliği Algılandı"
+            "value" : "Zaman Değişikliği Tespit Edildi"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Виявлено Зміну Часу"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã phát hiện thay đổi thời gian"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Time Change Detected"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "检测到时间变更"
+            "value" : "检测到时间变化"
           }
         }
       }
@@ -22105,16 +27567,10 @@
             "value" : "بلوتوث مودوس شاكيلين"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bluetooth modus schakelen"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bluetooth modus schakelen"
+            "value" : "Bluetooth-tilstand til/fra"
           }
         },
         "de" : {
@@ -22143,7 +27599,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Toggle Bluetooth mode"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Toggle Bluetooth mode"
           }
         },
@@ -22153,15 +27615,9 @@
             "value" : "Modus Bluetooth"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ブルートゥース・モデル"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Toggle Bluetooth mode"
           }
         },
@@ -22177,22 +27633,22 @@
             "value" : "Bluetooth modus schakelen"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alternar o modo Bluetooth"
+            "state" : "new",
+            "value" : "Toggle Bluetooth mode"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bluetooth modus schakelen"
+            "state" : "new",
+            "value" : "Toggle Bluetooth mode"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bluetooth modus schakelen"
+            "value" : "Переключить режим Bluetooth"
           }
         },
         "sk" : {
@@ -22213,9 +27669,21 @@
             "value" : "Bluetooth modunu aç / kapat"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Перемкнути режим Bluetooth"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Chuyển đổi chế độ Bluetooth"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Toggle Bluetooth mode"
           }
         },
@@ -22236,16 +27704,10 @@
             "value" : "تبديل النغمة الصامتة؟"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Přepínání tichého tónu?"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Toggle lydløs tone?"
+            "value" : "Lydløs tone til/fra?"
           }
         },
         "de" : {
@@ -22274,7 +27736,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Toggle silent tone?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Toggle silent tone?"
           }
         },
@@ -22284,15 +27752,9 @@
             "value" : "Tasto silenzioso?"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "トグル・サイレント・トーン？"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Toggle silent tone?"
           }
         },
@@ -22308,22 +27770,22 @@
             "value" : "Przełączyć cichy dźwięk?"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Alternar o tom silencioso?"
+            "state" : "new",
+            "value" : "Toggle silent tone?"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Toggle ton tăcut?"
+            "state" : "new",
+            "value" : "Toggle silent tone?"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Тумблер без звука?"
+            "value" : "Включить фоновый звук?"
           }
         },
         "sk" : {
@@ -22344,16 +27806,28 @@
             "value" : "Sessiz tonu değiştirelim mi?"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Увімкнути беззвучний сигнал?"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Chuyển đổi chế độ im lặng không?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Toggle silent tone?"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "切换静音提示音？"
+            "value" : "切换无声音调？"
           }
         }
       }
@@ -22370,7 +27844,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mængde til genopfyldning af rør"
+            "value" : "Tubegenopfyldningsmængde"
           }
         },
         "de" : {
@@ -22399,7 +27873,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Tube refill amount"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Tube refill amount"
           }
         },
@@ -22409,7 +27889,7 @@
             "value" : "Quantità di ricarica del tubo"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Rør påfylling beløp"
@@ -22427,16 +27907,22 @@
             "value" : "Ilość napełnienia tuby"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Tube refill amount"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Quantidade de refil do tubo"
+            "state" : "new",
+            "value" : "Tube refill amount"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Количество пополнений в тюбике"
+            "value" : "Объем заполнения трубки"
           }
         },
         "sk" : {
@@ -22457,16 +27943,28 @@
             "value" : "Tüp dolum miktarı"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Кількість поповнень у тюбику"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Lượng ống nạp lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Tube refill amount"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "输注管补药剂量"
+            "value" : "软管填充量"
           }
         }
       }
@@ -22480,16 +27978,10 @@
             "value" : "نوع إعادة التعبئة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Typ náplně"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Type af refill"
+            "value" : "Genopfyldningstype"
           }
         },
         "de" : {
@@ -22518,7 +28010,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Type of refill"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Type of refill"
           }
         },
@@ -22528,15 +28026,9 @@
             "value" : "Tipo di ricarica"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "詰め替えタイプ"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Type of refill"
           }
         },
@@ -22552,22 +28044,22 @@
             "value" : "Typ wkładu"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tipo de refil"
+            "state" : "new",
+            "value" : "Type of refill"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tip de reumplere"
+            "state" : "new",
+            "value" : "Type of refill"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Тип пополнения"
+            "value" : "Тип заправки"
           }
         },
         "sk" : {
@@ -22588,16 +28080,28 @@
             "value" : "Dolum türü"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Тип заправки"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Kiểu nạp lại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Type of refill"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "补药类型"
+            "value" : "笔芯类型"
           }
         }
       }
@@ -22611,22 +28115,16 @@
             "value" : "U"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U"
+            "value" : "E"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U"
+            "value" : " IE"
           }
         },
         "es" : {
@@ -22637,7 +28135,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "U"
           }
         },
@@ -22649,6 +28147,12 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "U"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
             "value" : "U"
           }
@@ -22659,13 +28163,7 @@
             "value" : "U"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "E"
@@ -22674,46 +28172,52 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Eh"
+            "value" : "E"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "U"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "U"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "U"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "U"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U"
+            "value" : "Ед"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U"
+            "value" : "J"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U"
+            "value" : "E"
           }
         },
         "tr" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ü"
+          }
+        },
+        "uk" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "U"
@@ -22725,9 +28229,15 @@
             "value" : "U"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "U"
           }
         }
@@ -22739,25 +28249,19 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "وحدة/ساعة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/hod"
+            "value" : "وحدة لكل ساعة"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/time"
+            "value" : "E/t"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/Std."
+            "value" : "IE/Std"
           }
         },
         "es" : {
@@ -22768,8 +28272,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/h"
+            "state" : "new",
+            "value" : "U/hr"
           }
         },
         "fr" : {
@@ -22780,8 +28284,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "U/hr"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "U/óra"
           }
         },
         "it" : {
@@ -22790,13 +28300,7 @@
             "value" : "U/ora"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/時"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "E/t"
@@ -22805,49 +28309,55 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Eh/u"
+            "value" : "E/uur"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/godz."
+            "state" : "new",
+            "value" : "U/hr"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hr"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/hora"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "U/oră"
+            "state" : "new",
+            "value" : "U/hr"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "у/час"
+            "value" : "Ед/ч"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/hod"
+            "value" : "J/hod"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/timme"
+            "value" : "IE/h"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/saat"
+            "value" : "Ü/Sa"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "U/год"
           }
         },
         "vi" : {
@@ -22856,10 +28366,16 @@
             "value" : "U/hr"
           }
         },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "U/hr"
+          }
+        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/hr"
+            "value" : "U/小时"
           }
         }
       }
@@ -22869,14 +28385,8 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "غير معروف"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neznámý"
+            "state" : "new",
+            "value" : "Unknown"
           }
         },
         "da" : {
@@ -22911,8 +28421,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
             "value" : "Unknown"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ismeretlen"
           }
         },
         "it" : {
@@ -22921,13 +28437,7 @@
             "value" : "Sconosciuto"
           }
         },
-        "ja" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "不明"
-          }
-        },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ukjent"
@@ -22942,7 +28452,13 @@
         "pl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nieznany"
+            "value" : "Nieznana"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Unknown"
           }
         },
         "pt_BR" : {
@@ -22951,16 +28467,10 @@
             "value" : "Desconhecido"
           }
         },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Necunoscut"
-          }
-        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Неизвестный"
+            "value" : "Неизвестно"
           }
         },
         "sk" : {
@@ -22981,9 +28491,21 @@
             "value" : "Bilinmiyor"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невідомий"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Không xác định"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Unknown"
           }
         },
@@ -23002,12 +28524,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "خطأ غير معروف"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Neznámá chyba"
           }
         },
         "da" : {
@@ -23042,7 +28558,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Unknown error"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Unknown error"
           }
         },
@@ -23052,16 +28574,10 @@
             "value" : "Errore sconosciuto"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "不明なエラー"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ukjent feil"
+            "state" : "new",
+            "value" : "Unknown error"
           }
         },
         "nl" : {
@@ -23076,16 +28592,16 @@
             "value" : "Nieznany błąd"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Erro desconhecido"
+            "state" : "new",
+            "value" : "Unknown error"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Eroare necunoscută"
+            "state" : "new",
+            "value" : "Unknown error"
           }
         },
         "ru" : {
@@ -23112,9 +28628,21 @@
             "value" : "Bilinmeyen hata"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Невідома помилка"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Lỗi không xác định"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Unknown error"
           }
         },
@@ -23133,12 +28661,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "خيارات المستخدم"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Uživatelské možnosti"
           }
         },
         "da" : {
@@ -23173,7 +28695,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "User options"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "User options"
           }
         },
@@ -23183,16 +28711,10 @@
             "value" : "Opzioni utente"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "ユーザーオプション"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Brukeralternativer"
+            "state" : "new",
+            "value" : "User options"
           }
         },
         "nl" : {
@@ -23207,28 +28729,28 @@
             "value" : "Opcje użytkownika"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opções do usuário"
+            "state" : "new",
+            "value" : "User options"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Opțiuni utilizator"
+            "state" : "new",
+            "value" : "User options"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Пользовательские опции"
+            "value" : "Настройки пользователя"
           }
         },
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Možnosti používateľa"
+            "value" : "Používateľské nastavenia"
           }
         },
         "sv" : {
@@ -23243,9 +28765,21 @@
             "value" : "Kullanıcı seçenekleri"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Опції користувача"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "User options"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "User options"
           }
         },
@@ -23266,22 +28800,16 @@
             "value" : "الاهتزاز"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vibrace"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vibrationer"
+            "value" : "Vibration"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vibration"
+            "value" : "Vibrieren"
           }
         },
         "es" : {
@@ -23304,26 +28832,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Vibration"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Vibration"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vibrazione"
+            "value" : "Vibrazioni"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "振動"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vibrasjon"
+            "state" : "new",
+            "value" : "Vibration"
           }
         },
         "nl" : {
@@ -23338,16 +28866,16 @@
             "value" : "Wibracje"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vibração"
+            "state" : "new",
+            "value" : "Vibration"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vibrații"
+            "state" : "new",
+            "value" : "Vibration"
           }
         },
         "ru" : {
@@ -23374,9 +28902,21 @@
             "value" : "Titreşim"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Вібрація"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Chế độ rung"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Vibration"
           }
         },
@@ -23391,16 +28931,130 @@
     "WARNING: Please don't use this until you've read the documentation" : {
       "comment" : "Warning message continuous mode",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ATTENZIONE: non utilizzare questo strumento prima di aver letto la documentazione"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "ADVARSEL: Ikke bruk dette før du har lest dokumentasjonen"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "VARNING: Använd inte denna förrän du läst dokumentationen"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: Please don't use this until you've read the documentation"
           }
         },
         "zh-Hans" : {
@@ -23452,7 +29106,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "WARNING: USE WITH CAUTION!"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "WARNING: USE WITH CAUTION!"
           }
         },
@@ -23462,10 +29122,10 @@
             "value" : "ATTENZIONE: USARE CON CAUTELA!"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ADVARSEL: BRUK MED FORSIKTIGHET!"
+            "value" : "ADVARSEL: BRUK MED ADVARSEL!"
           }
         },
         "nl" : {
@@ -23480,16 +29140,22 @@
             "value" : "OSTRZEŻENIE: UŻYWAĆ OSTROŻNIE!"
           }
         },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "WARNING: USE WITH CAUTION!"
+          }
+        },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "AVISO: USE COM CUIDADO!"
+            "state" : "new",
+            "value" : "WARNING: USE WITH CAUTION!"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ПРЕДУПРЕЖДЕНИЕ: ИСПОЛЬЗОВАТЬ С ОСТОРОЖНОСТЬЮ!"
+            "value" : "ВНИМАНИЕ: ИСПОЛЬЗОВАТЬ С ОСТОРОЖНОСТЬЮ!"
           }
         },
         "sk" : {
@@ -23510,9 +29176,21 @@
             "value" : "UYARI: DİKKATLİ KULLANIN!"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "УВАГА: ВИКОРИСТОВУЙТЕ ОБЕРЕЖНО!"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "CẢNH BÁO: SỬ DỤNG THẬN TRỌNG!"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "WARNING: USE WITH CAUTION!"
           }
         },
@@ -23533,16 +29211,10 @@
             "value" : "ما هذا؟"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Co je to?"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hvad er det her for noget?"
+            "value" : "Hvad er dette?"
           }
         },
         "de" : {
@@ -23571,26 +29243,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "What is this?"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "What is this?"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cos'è questo?"
+            "value" : "Che cos'è questo?"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "これは何だ？"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Hva er dette?"
+            "state" : "new",
+            "value" : "What is this?"
           }
         },
         "nl" : {
@@ -23605,16 +29277,16 @@
             "value" : "Co to jest?"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "O que é isso?"
+            "state" : "new",
+            "value" : "What is this?"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ce este aceasta?"
+            "state" : "new",
+            "value" : "What is this?"
           }
         },
         "ru" : {
@@ -23641,9 +29313,21 @@
             "value" : "Bu da ne?"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Що це?"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đây là gì?"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "What is this?"
           }
         },
@@ -23657,6 +29341,12 @@
     },
     "Yes" : {
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "نعم"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23675,6 +29365,12 @@
             "value" : "Sí"
           }
         },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kyllä"
+          }
+        },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23683,17 +29379,23 @@
         },
         "he" : {
           "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
             "state" : "translated",
-            "value" : "כן"
+            "value" : "Igen"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "SÌ"
+            "value" : "Sì"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ja"
@@ -23707,14 +29409,20 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tak"
+            "state" : "new",
+            "value" : "Yes"
           }
         },
-        "ro" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da"
+            "state" : "new",
+            "value" : "Yes"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes"
           }
         },
         "ru" : {
@@ -23729,16 +29437,40 @@
             "value" : "Áno"
           }
         },
-        "tr" : {
+        "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Evet"
+            "value" : "Ja"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Có"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "是"
+            "state" : "new",
+            "value" : "Yes"
           }
         }
       }
@@ -23750,12 +29482,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "نعم، 1 ساعة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ano, 1 hodina"
           }
         },
         "da" : {
@@ -23790,7 +29516,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Yes, 1 hour"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, 1 hour"
           }
         },
@@ -23800,16 +29532,10 @@
             "value" : "Sì, 1 ora"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "はい、1時間"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja, 1 time"
+            "state" : "new",
+            "value" : "Yes, 1 hour"
           }
         },
         "nl" : {
@@ -23824,16 +29550,16 @@
             "value" : "Tak, 1 godzina"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sim, 1 hora"
+            "state" : "new",
+            "value" : "Yes, 1 hour"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da, 1 oră"
+            "state" : "new",
+            "value" : "Yes, 1 hour"
           }
         },
         "ru" : {
@@ -23860,9 +29586,21 @@
             "value" : "Evet, 1 saat"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так, 1 година"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Có, 1 giờ"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, 1 hour"
           }
         },
@@ -23881,12 +29619,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "نعم، 5 دقائق"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ano, 5 minut"
           }
         },
         "da" : {
@@ -23921,7 +29653,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Yes, 5 minutes"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, 5 minutes"
           }
         },
@@ -23931,16 +29669,10 @@
             "value" : "Sì, 5 minuti"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "はい、5分"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja, 5 minutter"
+            "state" : "new",
+            "value" : "Yes, 5 minutes"
           }
         },
         "nl" : {
@@ -23955,16 +29687,16 @@
             "value" : "Tak, 5 minut"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sim, 5 minutos"
+            "state" : "new",
+            "value" : "Yes, 5 minutes"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da, 5 minute"
+            "state" : "new",
+            "value" : "Yes, 5 minutes"
           }
         },
         "ru" : {
@@ -23991,9 +29723,21 @@
             "value" : "Evet, 5 dakika"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так, 5 хвилин"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Có, 5 phút"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, 5 minutes"
           }
         },
@@ -24012,12 +29756,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "نعم، 15 دقيقة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ano, 15 minut"
           }
         },
         "da" : {
@@ -24052,7 +29790,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Yes, 15 minutes"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, 15 minutes"
           }
         },
@@ -24062,16 +29806,10 @@
             "value" : "Sì, 15 minuti"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "はい、15分"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja, 15 minutter"
+            "state" : "new",
+            "value" : "Yes, 15 minutes"
           }
         },
         "nl" : {
@@ -24086,16 +29824,16 @@
             "value" : "Tak, 15 minut"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sim, 15 minutos"
+            "state" : "new",
+            "value" : "Yes, 15 minutes"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da, 15 minute"
+            "state" : "new",
+            "value" : "Yes, 15 minutes"
           }
         },
         "ru" : {
@@ -24122,9 +29860,21 @@
             "value" : "Evet, 15 dakika"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так, 15 хвилин"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Có, 15 phút"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, 15 minutes"
           }
         },
@@ -24143,12 +29893,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "نعم، 30 دقيقة"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ano, 30 minut"
           }
         },
         "da" : {
@@ -24183,7 +29927,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Yes, 30 minutes"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, 30 minutes"
           }
         },
@@ -24193,16 +29943,10 @@
             "value" : "Sì, 30 minuti"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "はい、30分"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja, 30 minutter"
+            "state" : "new",
+            "value" : "Yes, 30 minutes"
           }
         },
         "nl" : {
@@ -24217,16 +29961,16 @@
             "value" : "Tak, 30 minut"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sim, 30 minutos"
+            "state" : "new",
+            "value" : "Yes, 30 minutes"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da, 30 de minute"
+            "state" : "new",
+            "value" : "Yes, 30 minutes"
           }
         },
         "ru" : {
@@ -24253,9 +29997,21 @@
             "value" : "Evet, 30 dakika"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так, 30 хвилин"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Có, 30 phút"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, 30 minutes"
           }
         },
@@ -24276,16 +30032,10 @@
             "value" : "نعم، تعطيل مزامنة البلعة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ano, vypněte synchronizaci bolusu"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, deaktiver bolus-synkronisering"
+            "value" : "Ja, deaktivér bolus-synkning"
           }
         },
         "de" : {
@@ -24314,26 +30064,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Yes, disable bolus syncing"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, disable bolus syncing"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sì, disattiva la sincronizzazione del bolo"
+            "value" : "Sì, disabilitare la sincronizzazione del bolo"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "はい、ボーラス同期を無効にします"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja, deaktiver bolussynkronisering"
+            "state" : "new",
+            "value" : "Yes, disable bolus syncing"
           }
         },
         "nl" : {
@@ -24348,22 +30098,22 @@
             "value" : "Tak, wyłącz synchronizację bolusa"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sim, desativar a sincronização de bolus"
+            "state" : "new",
+            "value" : "Yes, disable bolus syncing"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da, dezactivați sincronizarea bolusului"
+            "state" : "new",
+            "value" : "Yes, disable bolus syncing"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Да, отключите синхронизацию болюсов"
+            "value" : "Да, отключить синхронизацию болюсов"
           }
         },
         "sk" : {
@@ -24384,16 +30134,28 @@
             "value" : "Evet, bolus senkronizasyonunu devre dışı bırakın"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так, вимкнути болюсну синхронізацію"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Có, tắt đồng bộ bolus"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, disable bolus syncing"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "好的，已禁用追加胰岛素同步。"
+            "value" : "是，禁用栓剂同步"
           }
         }
       }
@@ -24407,16 +30169,10 @@
             "value" : "نعم، تعطيل النغمات الصامتة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ano, Zakázat tiché tóny"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, deaktiver lydløse toner"
+            "value" : "Ja, deaktivér lydløse toner"
           }
         },
         "de" : {
@@ -24445,7 +30201,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Yes, Disable silent tones"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, Disable silent tones"
           }
         },
@@ -24455,16 +30217,10 @@
             "value" : "Sì, disattiva i toni silenziosi"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "はい、サイレントトーンを無効にする"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja, Deaktiver lydløse toner"
+            "state" : "new",
+            "value" : "Yes, Disable silent tones"
           }
         },
         "nl" : {
@@ -24479,22 +30235,22 @@
             "value" : "Tak, Wyłącz ciche dźwięki"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sim, desativar tons silenciosos"
+            "state" : "new",
+            "value" : "Yes, Disable silent tones"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da, Dezactivați tonurile silențioase"
+            "state" : "new",
+            "value" : "Yes, Disable silent tones"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Да, отключение беззвучных сигналов"
+            "value" : "Да, отключить фоновый звук"
           }
         },
         "sk" : {
@@ -24515,9 +30271,21 @@
             "value" : "Evet, Sessiz tonları devre dışı bırak"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так, Вимкнути беззвучні сигнали"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Có, Tắt âm báo im lặng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, Disable silent tones"
           }
         },
@@ -24538,16 +30306,10 @@
             "value" : "نعم، تمكين النغمات الصامتة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ano, Povolit tiché tóny"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, aktiver lydløse toner"
+            "value" : "Ja, aktivér lydløse toner"
           }
         },
         "de" : {
@@ -24576,26 +30338,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Yes, Enable silent tones"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, Enable silent tones"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sì, attiva i toni silenziosi"
+            "value" : "Sì, abilita i toni silenziosi"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "はい、サイレントトーンを有効にする"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja, aktiver lydløse toner"
+            "state" : "new",
+            "value" : "Yes, Enable silent tones"
           }
         },
         "nl" : {
@@ -24610,22 +30372,22 @@
             "value" : "Tak, Włącz ciche dźwięki"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sim, habilitar tons silenciosos"
+            "state" : "new",
+            "value" : "Yes, Enable silent tones"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da, Activare tonuri silențioase"
+            "state" : "new",
+            "value" : "Yes, Enable silent tones"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Да, включение беззвучных сигналов"
+            "value" : "Да, включить фоновый звук"
           }
         },
         "sk" : {
@@ -24646,9 +30408,21 @@
             "value" : "Evet, Sessiz tonları etkinleştir"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так, увімкнути беззвучні сигнали"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Có, Bật âm báo im lặng"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, Enable silent tones"
           }
         },
@@ -24669,16 +30443,10 @@
             "value" : "نعم، أعد تمكين مزامنة البلعة"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ano, znovu povolte synchronizaci bolusu"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, genaktiver bolus-synkronisering"
+            "value" : "Ja, genaktivér bolus-synkning"
           }
         },
         "de" : {
@@ -24707,26 +30475,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Yes, re-enable bolus syncing"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, re-enable bolus syncing"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sì, riattiva la sincronizzazione del bolo"
+            "value" : "Sì, riattivare la sincronizzazione del bolo"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "はい、ボーラス同期を再度有効にしてください"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja, aktiver bolussynkronisering på nytt"
+            "state" : "new",
+            "value" : "Yes, re-enable bolus syncing"
           }
         },
         "nl" : {
@@ -24741,22 +30509,22 @@
             "value" : "Tak, ponownie włącz synchronizację bolusa"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sim, reative a sincronização de bolus"
+            "state" : "new",
+            "value" : "Yes, re-enable bolus syncing"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da, reactivați sincronizarea bolusurilor"
+            "state" : "new",
+            "value" : "Yes, re-enable bolus syncing"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Да, снова включите синхронизацию болюсов"
+            "value" : "Да, включить синхронизацию болюсов"
           }
         },
         "sk" : {
@@ -24777,16 +30545,28 @@
             "value" : "Evet, bolus senkronizasyonunu yeniden etkinleştirin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так, повторно ввімкнути болюсну синхронізацію"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Có, bật lại đồng bộ bolus"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, re-enable bolus syncing"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "好的，已重新启用追加胰岛素同步。"
+            "value" : "是，重新启用药量同步"
           }
         }
       }
@@ -24798,12 +30578,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "نعم، قم بالتبديل إلى الوضع المستمر"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ano, přepnutí na nepřetržitý režim"
           }
         },
         "da" : {
@@ -24838,7 +30612,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Yes, Switch to continuous mode"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, Switch to continuous mode"
           }
         },
@@ -24848,16 +30628,10 @@
             "value" : "Sì, passa alla modalità continua"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "はい、連続モードに切り替える"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja, bytt til kontinuerlig modus"
+            "state" : "new",
+            "value" : "Yes, Switch to continuous mode"
           }
         },
         "nl" : {
@@ -24872,22 +30646,22 @@
             "value" : "Tak, przełącz na tryb ciągły"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sim, mudar para o modo contínuo"
+            "state" : "new",
+            "value" : "Yes, Switch to continuous mode"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da, Comutare la modul continuu"
+            "state" : "new",
+            "value" : "Yes, Switch to continuous mode"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Да, переключение в непрерывный режим"
+            "value" : "Да, переключить в непрерывный режим"
           }
         },
         "sk" : {
@@ -24908,9 +30682,21 @@
             "value" : "Evet, Sürekli moda geç"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так, перейти в безперервний режим"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Có, chuyển sang chế độ liên tục"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, Switch to continuous mode"
           }
         },
@@ -24929,12 +30715,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "نعم، قم بالتبديل إلى الوضع التفاعلي"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ano, přepnutí do interaktivního režimu"
           }
         },
         "da" : {
@@ -24969,7 +30749,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Yes, Switch to interactive mode"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, Switch to interactive mode"
           }
         },
@@ -24979,16 +30765,10 @@
             "value" : "Sì, passa alla modalità interattiva"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "はい、対話モードに切り替える"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja, bytt til interaktiv modus"
+            "state" : "new",
+            "value" : "Yes, Switch to interactive mode"
           }
         },
         "nl" : {
@@ -25003,22 +30783,22 @@
             "value" : "Tak, przełącz na tryb interaktywny"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sim, mudar para o modo interativo"
+            "state" : "new",
+            "value" : "Yes, Switch to interactive mode"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da, treceți la modul interactiv"
+            "state" : "new",
+            "value" : "Yes, Switch to interactive mode"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Да, переключение в интерактивный режим"
+            "value" : "Да, переключить в интерактивный режим"
           }
         },
         "sk" : {
@@ -25039,9 +30819,21 @@
             "value" : "Evet, Etkileşimli moda geç"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так, перейти в інтерактивний режим"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Có, chuyển sang chế độ tương tác"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, Switch to interactive mode"
           }
         },
@@ -25062,12 +30854,6 @@
             "value" : "نعم، المزامنة مع الوقت الحالي"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ano, synchronizace s aktuálním časem"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25077,7 +30863,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, Synchronisierung mit der aktuellen Zeit"
+            "value" : "Ja, mit aktueller Zeit synchronisieren"
           }
         },
         "es" : {
@@ -25088,62 +30874,62 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Kyllä, synkronointi nykyiseen aikaan"
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Oui, synchronisation avec l'heure actuelle"
+            "value" : "Oui, synchroniser avec l'heure actuelle"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, Sync to Current Time"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sì, sincronizza con l'orario corrente"
+            "value" : "Sì, sincronizza con l'ora corrente"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "はい、現在時刻に同期"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Ja, Synkroniser til gjeldende tid"
+            "value" : "Ja, synkroniser til gjeldende tid"
           }
         },
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, synchroniseren met huidige tijd"
+            "value" : "Ja, zet naar huidige tijd"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Tak, zsynchronizuj z bieżącym czasem"
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
           }
         },
         "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sim, sincronização com a hora atual"
-          }
-        },
-        "ro" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Da, sincronizați cu ora curentă"
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
           }
         },
         "ru" : {
@@ -25155,31 +30941,43 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Áno, synchronizácia s aktuálnym časom"
+            "value" : "Áno, zosynchronizovať s aktuálnym časom"
           }
         },
         "sv" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, synkroniseras med aktuell tid"
+            "value" : "Ja, synkronisera med aktuell tid"
           }
         },
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Evet, Geçerli Saatle Senkronize Et"
+            "value" : "Evet güncelle"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Так, синхронізувати з поточним часом"
           }
         },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Có, đồng bộ với thời gian hiện tại"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Yes, Sync to Current Time"
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "是，与当前时间同步"
+            "state" : "new",
+            "value" : "Yes, Sync to Current Time"
           }
         }
       }
@@ -25191,12 +30989,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "أنت "
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vaše "
           }
         },
         "da" : {
@@ -25231,7 +31023,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Your "
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Your "
           }
         },
@@ -25241,16 +31039,10 @@
             "value" : "Il tuo "
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "あなたの "
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Din"
+            "state" : "new",
+            "value" : "Your "
           }
         },
         "nl" : {
@@ -25265,16 +31057,16 @@
             "value" : "Twój "
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seu "
+            "state" : "new",
+            "value" : "Your "
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "dvs. "
+            "state" : "new",
+            "value" : "Your "
           }
         },
         "ru" : {
@@ -25286,7 +31078,7 @@
         "sk" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vaša stránka "
+            "value" : "Vaša "
           }
         },
         "sv" : {
@@ -25301,9 +31093,21 @@
             "value" : "Senin "
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваша "
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Your "
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Your "
           }
         },
@@ -25324,16 +31128,10 @@
             "value" : "لقد تم الوصول إلى الحد الأساسي اليومي. يرجى الاتصال بموزع دانا الخاص بك لزيادة الحد المسموح به"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Váš denní bazální limit byl dosažen. Pro zvýšení limitu se obraťte na svého distributora Dana."
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Din daglige basalgrænse er nået. Kontakt din Dana-distributør for at øge grænsen."
+            "value" : "Den daglige basalgrænse er nået. Kontakt Dana-distributøren for at øge grænsen"
           }
         },
         "de" : {
@@ -25362,26 +31160,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Your daily basal limit has been reached. Please contact your Dana distributer to increase the limit"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Your daily basal limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Il tuo limite giornaliero di basale è stato raggiunto. Contatta il tuo fornitore Dana per aumentare il limite."
+            "value" : "Il limite giornaliero di basale è stato raggiunto. Contattare il distributore Dana per aumentare il limite."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "1日の基礎摂取量の上限に達しました。制限を増やすには、Danaの販売代理店にご連絡ください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Din daglige basalgrense er nådd. Ta kontakt med Dana-distributøren din for å øke grensen"
+            "state" : "new",
+            "value" : "Your daily basal limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
         "nl" : {
@@ -25396,22 +31194,22 @@
             "value" : "Osiągnięto dzienny limit dawki podstawowej. Skontaktuj się z dystrybutorem Dana, aby zwiększyć limit"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seu limite diário de basal foi atingido. Entre em contato com o distribuidor Dana para aumentar o limite"
+            "state" : "new",
+            "value" : "Your daily basal limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limita dvs. zilnică de bazalină a fost atinsă. Vă rugăm să contactați distribuitorul Dana pentru a crește limita"
+            "state" : "new",
+            "value" : "Your daily basal limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ваш суточный лимит базала достигнут. Обратитесь к дистрибьютору Dana, чтобы увеличить лимит."
+            "value" : "Ваш суточный лимит Базала достигнут. Обратитесь к дистрибьютору Dana, чтобы увеличить лимит"
           }
         },
         "sk" : {
@@ -25432,9 +31230,21 @@
             "value" : "Günlük bazal limitinize ulaşıldı. Limiti artırmak için lütfen Dana distribütörünüzle iletişime geçin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваш добовий базальний ліміт досягнуто. Щоб збільшити ліміт, зверніться до свого дистриб’ютора Dana"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã đạt đến giới hạn bolus tối đa. Vui lòng thử lượng thấp hơn hoặc tăng giới hạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Your daily basal limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
@@ -25455,16 +31265,10 @@
             "value" : "تم الوصول إلى الحد اليومي للأنسولين. يرجى الاتصال بموزع دانا الخاص بك لزيادة الحد المسموح به"
           }
         },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Váš denní inzulínový limit byl dosažen. Pro zvýšení limitu se obraťte na svého distributora Dana"
-          }
-        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Din daglige insulin-grænse er nået. Kontakt venligst din Dana-distributør for at øge grænsen."
+            "value" : "Den daglige insulin-grænse er nået. Kontakt Dana-distributøren for at øge grænsen"
           }
         },
         "de" : {
@@ -25493,26 +31297,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Your daily insulin limit has been reached. Please contact your Dana distributer to increase the limit"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Your daily insulin limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Il tuo limite giornaliero d'insulina è stato raggiunto. Contatta il tuo fornitore Dana per aumentare il limite."
+            "value" : "Il limite giornaliero di insulina è stato raggiunto. Contattare il distributore Dana per aumentare il limite."
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "インスリンの1日あたりの摂取量が上限に達しました。限度額を増やすには、ダナ販売店にご連絡ください。"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Din daglige insulingrense er nådd. Kontakt Dana-distributøren din for å øke grensen"
+            "state" : "new",
+            "value" : "Your daily insulin limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
         "nl" : {
@@ -25527,22 +31331,22 @@
             "value" : "Osiągnięto dzienny limit insuliny. Skontaktuj się z dystrybutorem Dana, aby zwiększyć limit"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Seu limite diário de insulina foi atingido. Entre em contato com o distribuidor da Dana para aumentar o limite"
+            "state" : "new",
+            "value" : "Your daily insulin limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Limita dvs. zilnică de insulină a fost atinsă. Vă rugăm să contactați distribuitorul Dana pentru a crește limita"
+            "state" : "new",
+            "value" : "Your daily insulin limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ваш ежедневный лимит инсулина исчерпан. Обратитесь к дистрибьютору компании \"Дана\", чтобы увеличить лимит."
+            "value" : "Ваш суточный лимит инсулина достигнут. Обратитесь к дистрибьютору Dana, чтобы увеличить лимит"
           }
         },
         "sk" : {
@@ -25563,9 +31367,21 @@
             "value" : "Günlük insülin limitinize ulaşıldı. Limiti artırmak için lütfen Dana distribütörünüzle iletişime geçin"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваш добовий ліміт інсуліну досягнуто. Щоб збільшити ліміт, зверніться до свого дистриб’ютора Dana"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Đã đạt giới hạn insulin hàng ngày của bạn. Vui lòng liên hệ với nhà phân phối Dana của bạn để tăng giới hạn"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Your daily insulin limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
@@ -25580,16 +31396,130 @@
     "Your pump is disconnected longer than 5 minutes!" : {
       "comment" : "Body disconnect warning notification",
       "localizations" : {
+        "ar" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "da" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "de" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "es" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "fi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "fr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "he" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il tuo microinfusore è disconnesso da più di 5 minuti!"
           }
         },
-        "nb" : {
+        "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pumpen din har vært frakoblet i mer enn 5 minutter!"
+          }
+        },
+        "nl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "pl" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "pt" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "pt_BR" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "sk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "sv" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Din pump är frånkopplad längre än 5 minuter!"
+          }
+        },
+        "tr" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "vi" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
+            "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
         "zh-Hans" : {
@@ -25607,12 +31537,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "لا تزال المضخة مفصولة بعد الفترة المحددة!"
-          }
-        },
-        "cs" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Vaše čerpadlo je po uplynutí nastavené doby stále odpojeno!"
           }
         },
         "da" : {
@@ -25647,26 +31571,26 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "translated",
+            "state" : "new",
+            "value" : "Your pump is still disconnected after the set period!"
+          }
+        },
+        "hu" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Your pump is still disconnected after the set period!"
           }
         },
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Il tuo microinfusore è ancora disconnesso dopo il periodo di configurazione!"
+            "value" : "La pompa è ancora scollegata dopo il periodo impostato!"
           }
         },
-        "ja" : {
+        "nb-NO" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "設定時間経過後もポンプは切断されたままです！"
-          }
-        },
-        "nb" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pumpen din er fortsatt frakoblet etter den angitte perioden!"
+            "state" : "new",
+            "value" : "Your pump is still disconnected after the set period!"
           }
         },
         "nl" : {
@@ -25681,22 +31605,22 @@
             "value" : "Pompa jest nadal odłączona po upływie ustawionego czasu!"
           }
         },
-        "pt_BR" : {
+        "pt" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Sua bomba ainda está desconectada após o período definido!"
+            "state" : "new",
+            "value" : "Your pump is still disconnected after the set period!"
           }
         },
-        "ro" : {
+        "pt_BR" : {
           "stringUnit" : {
-            "state" : "translated",
-            "value" : "Pompa dvs. este încă deconectată după perioada stabilită!"
+            "state" : "new",
+            "value" : "Your pump is still disconnected after the set period!"
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ваш насос по-прежнему отключен по истечении заданного периода!"
+            "value" : "Ваша помпа по-прежнему отключена по истечении заданного периода!"
           }
         },
         "sk" : {
@@ -25717,9 +31641,21 @@
             "value" : "Ayarlanan süreden sonra pompanızın bağlantısı hala kesik!"
           }
         },
+        "uk" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ваша помпа все ще відключена після встановленого періоду!"
+          }
+        },
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "Máy bơm của bạn vẫn bị ngắt kết nối sau thời gian đã đặt!"
+          }
+        },
+        "yy-YY" : {
+          "stringUnit" : {
+            "state" : "new",
             "value" : "Your pump is still disconnected after the set period!"
           }
         },

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -10,6 +10,12 @@
             "value" : " جاهز للاستخدام!"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " je připraven k použití!"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -42,7 +48,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : " is ready to be used!"
           }
         },
@@ -56,6 +62,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : " è pronto per essere utilizzato!"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "er klar til bruk!"
           }
         },
         "nb-NO" : {
@@ -193,6 +205,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gå til Bluetooth-innstillingene, glem denne enheten og prøv på nytt."
           }
         },
         "nb-NO" : {
@@ -337,6 +355,12 @@
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "new",
@@ -474,6 +498,12 @@
             "value" : "%@U"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@E"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -609,6 +639,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ unità rimanenti alle ore %2$@"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ enheter gjenstår ved %2$@"
           }
         },
         "nb-NO" : {
@@ -753,6 +789,12 @@
             "value" : "%1$u %2$@"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$u %2$@"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "new",
@@ -890,6 +932,12 @@
             "value" : "12 sec/E"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 sek/E"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -980,6 +1028,12 @@
             "value" : "12 ثانية/و"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 sec/U"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -989,7 +1043,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "12 Sek/U"
+            "value" : "12 sec/U"
           }
         },
         "en" : {
@@ -1012,13 +1066,13 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/U"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/U"
           }
         },
@@ -1034,6 +1088,12 @@
             "value" : "12 sec/U"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 sek/u"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "new",
@@ -1043,7 +1103,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "12 sec/E"
+            "value" : "12 sec/U"
           }
         },
         "pl" : {
@@ -1123,6 +1183,12 @@
             "value" : "ترميز 12 ساعة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zápis 12h"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1155,7 +1221,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12h notation"
           }
         },
@@ -1169,6 +1235,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Notazione 12h"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 timers notasjon"
           }
         },
         "nb-NO" : {
@@ -1260,10 +1332,16 @@
             "value" : "عرض 24 ساعة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "24hodinový displej"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "24-timers visning"
+            "value" : "24 timers visning"
           }
         },
         "de" : {
@@ -1292,7 +1370,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "24h display"
           }
         },
@@ -1306,6 +1384,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Display 24 ore su 24"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "24 timers visning"
           }
         },
         "nb-NO" : {
@@ -1397,10 +1481,16 @@
             "value" : "ترميز 24 ساعة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "24hodinový zápis"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "24-timers notation"
+            "value" : "24 timers notation"
           }
         },
         "de" : {
@@ -1429,7 +1519,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "24h notation"
           }
         },
@@ -1443,6 +1533,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Notazione 24h"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "24-timers notasjon"
           }
         },
         "nb-NO" : {
@@ -1582,6 +1678,12 @@
             "value" : "30 sec/E"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 sek/E"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1672,6 +1774,12 @@
             "value" : "30 ثانية/و"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 sec/U"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1681,7 +1789,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "30 Sek/U"
+            "value" : "30 sec/U"
           }
         },
         "en" : {
@@ -1704,13 +1812,13 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/U"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/U"
           }
         },
@@ -1726,6 +1834,12 @@
             "value" : "30 sec/U"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 sek/u"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "new",
@@ -1735,7 +1849,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "30 sec/E"
+            "value" : "30 sec/U"
           }
         },
         "pl" : {
@@ -1863,6 +1977,12 @@
             "value" : "60 sec/E"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "60 sek/E"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1953,6 +2073,12 @@
             "value" : "60 ثانية/و"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "60 sec/U"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1962,7 +2088,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "60 Sek/U"
+            "value" : "60 sec/U"
           }
         },
         "en" : {
@@ -1985,13 +2111,13 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/U"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/U"
           }
         },
@@ -2007,6 +2133,12 @@
             "value" : "60 sec/U"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "60 sek/E"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "new",
@@ -2016,7 +2148,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "60 sec/E"
+            "value" : "60 sec/U"
           }
         },
         "pl" : {
@@ -2096,10 +2228,16 @@
             "value" : "لقد تم إعداد تذكير بفحص مستوى الجلوكوز في الدم في المضخة وتم تشغيله. يُرجى إزالته أو إعطاء مستوى الجلوكوز للمضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "V pumpě byla nastavena připomínka kontroly glykemie, která se spustí. Prosím, odstraňte ji nebo zadejte hladinu glukózy do pumpy."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "En påmindelse om blodsukkerkontrol i er blevet opsat i pumpen og er udløst. Fjern den, eller informér pumpen om dit blodsukkerniveau"
+            "value" : "Der er installeret en påmindelse om blodsukkerkontrol i din pumpe, og den udløses. Fjern den, eller giv dit blodsukkerniveau til pumpen."
           }
         },
         "de" : {
@@ -2128,7 +2266,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "A blood glucose check reminder has been setup in your pump and is triggered. Please remove it or give your glucose level to the pump"
           }
         },
@@ -2142,6 +2280,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nel microinfusore è stato impostato un promemoria per il controllo della glicemia, che è stato attivato. Si prega di rimuoverlo o di fornire il livello di glucosio al microinfusore."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "En påminnelse om blodsukkerkontroll er satt opp i pumpen og utløses. Fjern den eller gi glukosenivået til pumpen"
           }
         },
         "nb-NO" : {
@@ -2233,6 +2377,12 @@
             "value" : "مهلة البلعة نشطة. لا يمكن إكمال دورة الحلقة حتى تصبح المهلة غير نشطة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Časový limit bolusu je aktivní. Cyklus smyčky nelze dokončit, dokud není časový limit neaktivní."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2265,7 +2415,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive"
           }
         },
@@ -2279,6 +2429,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "È attivo un timeout del bolo. Il ciclo del bolo non può essere completato finché il timeout non è attivo."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolus-timeout er aktiv. Sløyfen kan ikke fullføres før timeouten er over."
           }
         },
         "nb-NO" : {
@@ -2356,7 +2512,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "栓剂超时激活。在超时未激活之前，循环周期无法完成"
+            "value" : "大剂量推注超时，Loop 将在该超时状态解除后恢复正常工作。"
           }
         }
       }
@@ -2370,10 +2526,16 @@
             "value" : "تم إلغاء الإجراء، لأن المضخة مشغولة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Akce byla zrušena, protože čerpadlo je obsazeno."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Handlingen er blevet afbrudt, da pumpen er optaget"
+            "value" : "Handlingen er blevet aflyst, fordi pumpen er optaget"
           }
         },
         "de" : {
@@ -2402,7 +2564,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Action has been canceled, because the pump is busy"
           }
         },
@@ -2416,6 +2578,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "L'azione è stata annullata perché la pompa è occupata."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Handlingen er avbrutt fordi pumpen er opptatt"
           }
         },
         "nb-NO" : {
@@ -2507,10 +2675,16 @@
             "value" : "بعد إعداد نوع الأنسولين وسرعة البلعة، ستظهر لك شاشة تحتوي على جميع مضخات دانا الموجودة. حدد المضخة التي تريد ربطها مع %1$@."
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Po nastavení typu inzulínu a rychlosti bolusu se zobrazí obrazovka se všemi nalezenými pumpami Dana. Vyberte pumpu, kterou chcete propojit se stránkou %1$@."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Efter opsætning af insulintype og bolushastighed, får man vist en skærm med alle fundne Dana-pumper. Vælg den pumpe, der skal forbindes med %1$@."
+            "value" : "Når du har indstillet insulintype og bolushastighed, får du vist en skærm med alle fundne Dana-pumper. Vælg den pumpe, du vil forbinde med %1$@."
           }
         },
         "de" : {
@@ -2545,7 +2719,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "After setting up the insulin type and bolus speed, you will see a screen with all found Dana pumps. Select the pump you want to link with %1$@."
           }
         },
@@ -2559,6 +2733,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dopo aver impostato il tipo di insulina e la velocità del bolo, verrà visualizzata una schermata con tutti i microinfusori Dana trovati. Selezionare il microinfusore che si desidera collegare a %1$@."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Etter at du har konfigurert insulintype og bolushastighet, vil du se en skjerm med alle funnet Dana-pumper. Velg pumpen du vil koble til %1$@."
           }
         },
         "nb-NO" : {
@@ -2650,10 +2830,16 @@
             "value" : "صفير المنبه"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pípání budíku"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Alarmbip"
+            "value" : "Alarmen bipper"
           }
         },
         "de" : {
@@ -2682,7 +2868,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Alarm beeps"
           }
         },
@@ -2696,6 +2882,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Segnale acustico dell'allarme"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alarmen piper"
           }
         },
         "nb-NO" : {
@@ -2787,10 +2979,16 @@
             "value" : "حدث خطأ غير معروف أثناء معالجة التنبيه من المضخة. يرجى الإبلاغ عن ذلك"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Při zpracování výstrahy z čerpadla došlo k neznámé chybě. Nahlaste to prosím"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "En ukendt fejl er opstået under behandlingen af alarmen fra pumpen. Anmeld venligst dette"
+            "value" : "Der er opstået en ukendt fejl under behandlingen af alarmen fra pumpen. Rapporter venligst dette"
           }
         },
         "de" : {
@@ -2819,7 +3017,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "An unknown error has occurred during processing the alert from the pump. Please report this"
           }
         },
@@ -2833,6 +3031,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Si è verificato un errore sconosciuto durante l'elaborazione dell'avviso dal microinfusore. Si prega di segnalare questo"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Det har oppstått en ukjent feil under behandlingen av varselet fra pumpen. Vennligst rapporter dette"
           }
         },
         "nb-NO" : {
@@ -2971,6 +3175,12 @@
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Er du sikker på at du vil gi bolus 5E?"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3046,7 +3256,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您确定要注射 5 单位追加胰岛素吗？"
+            "value" : "您确定要注射 5E 大剂量吗？"
           }
         }
       }
@@ -3105,6 +3315,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Er du sikker på at du vil sette temp basal til 200 % i 1 time?"
           }
         },
         "nb-NO" : {
@@ -3196,10 +3412,16 @@
             "value" : "هل أنت متأكد من رغبتك في التوقف عن استخدام Dana-i/RS؟"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Jste si jisti, že chcete přestat používat Dana-i/RS?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sikker på, at brug af Dana-i/RS skal ophøre?"
+            "value" : "Er du sikker på, at du vil stoppe med at bruge Dana-i/RS?"
           }
         },
         "de" : {
@@ -3228,7 +3450,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to stop using Dana-i/RS?"
           }
         },
@@ -3242,6 +3464,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Siete sicuri di voler smettere di usare Dana-i/RS?"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Er du sikker på at du vil slutte å bruke Dana-i/RS?"
           }
         },
         "nb-NO" : {
@@ -3333,10 +3561,16 @@
             "value" : "إضاءة خلفية في الوقت المحدد"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doba zapnutí podsvícení"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Baggrundslys på tidspunktet"
+            "value" : "Tændingstid for baggrundsbelysning"
           }
         },
         "de" : {
@@ -3360,12 +3594,12 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La vérité sur l'âge"
+            "value" : "Durée d'allumage du rétroéclairage"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Backlight on time"
           }
         },
@@ -3456,7 +3690,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "生活"
+            "value" : "背光开启时间"
           }
         }
       }
@@ -3468,6 +3702,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "القاعدية"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bazální"
           }
         },
         "da" : {
@@ -3496,13 +3736,13 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Basal"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Basal"
           }
         },
@@ -3607,6 +3847,12 @@
             "value" : "مقارنة قاعدية"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Základní porovnání"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3639,7 +3885,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Basal Compare"
           }
         },
@@ -3744,6 +3990,12 @@
             "value" : "بلوغ الحد الأساسي"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dosažení základního limitu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3776,7 +4028,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Basal limit reached"
           }
         },
@@ -3801,7 +4053,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basale limiet bereikt"
+            "value" : "Basaal limiet bereikt"
           }
         },
         "pl" : {
@@ -3878,7 +4130,13 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ملف الانسولين القاعدي"
+            "value" : "المظهر الجانبي القاعدي"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Základní profil"
           }
         },
         "da" : {
@@ -3890,7 +4148,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basal-Profil"
+            "value" : "Grundlegendes Profil"
           }
         },
         "es" : {
@@ -3902,18 +4160,18 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Perusinsuliiniprofiili"
+            "value" : "Perusprofiili"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Profil Basal"
+            "value" : "Profil de base"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Basal profile"
           }
         },
@@ -3938,7 +4196,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basaalprofiel"
+            "value" : "Basaal profiel"
           }
         },
         "pl" : {
@@ -4004,7 +4262,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "基础率配置文件"
+            "value" : "基本概况"
           }
         }
       }
@@ -4021,13 +4279,13 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batterialder"
+            "value" : "Batteriets alder"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batteriealter"
+            "value" : "Alter der Batterie"
           }
         },
         "es" : {
@@ -4038,19 +4296,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery age"
+            "state" : "translated",
+            "value" : "Akun ikä"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery age"
+            "state" : "translated",
+            "value" : "Âge de la batterie"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery age"
           }
         },
@@ -4140,8 +4398,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery age"
+            "state" : "translated",
+            "value" : "电池寿命"
           }
         }
       }
@@ -4288,8 +4546,14 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery level"
+            "state" : "translated",
+            "value" : "مستوى البطارية"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Úroveň nabití baterie"
           }
         },
         "da" : {
@@ -4301,7 +4565,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Batteriefüllung"
+            "value" : "Batteriestand"
           }
         },
         "es" : {
@@ -4312,8 +4576,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery level"
+            "state" : "translated",
+            "value" : "Akun varaustaso"
           }
         },
         "fr" : {
@@ -4325,7 +4589,7 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "מצב הסוללה"
+            "value" : "Battery level"
           }
         },
         "hu" : {
@@ -4414,8 +4678,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery level"
+            "state" : "translated",
+            "value" : "电池电量"
           }
         }
       }
@@ -4429,10 +4693,16 @@
             "value" : "قبل البدء بعملية الاقتران، يوصى بالتحقق من كلمة مرور المضخة وتحديثها إذا لزم الأمر. يمكنك القيام بذلك من خلال الانتقال إلى إعدادات المضخة -> إعدادات المستخدم -> كلمة المرور. كلمة المرور الافتراضية هي 1234، إذا كانت هذه هي كلمة المرور الخاصة بك، يُرجى التفكير في تغييرها"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Před zahájením procesu párování doporučujeme zkontrolovat a případně aktualizovat heslo čerpadla. To můžete provést v nastavení čerpadla -> nastavení uživatele -> heslo. Výchozí heslo je 1234, pokud je to vaše heslo, zvažte jeho změnu."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Før man går i gang med parringsprocessen, anbefales det at tjekke, og om nødvendigt opdatere, pumpens adgangskode. Det kan man gøre ved at gå til pumpeindstillinger -> brugerindstillinger -> adgangskode. Standardadgangskoden er 1234, og er det den adgangskode, man selv bruger, bør den skiftes"
+            "value" : "Før du går i gang med parringsprocessen, anbefales det at kontrollere og om nødvendigt opdatere pumpens adgangskode. Det kan du gøre ved at gå til pumpeindstillingerne -> brugerindstillinger -> adgangskode. Standardadgangskoden er 1234, og hvis det er din adgangskode, bør du overveje at ændre den."
           }
         },
         "de" : {
@@ -4461,7 +4731,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Before starting with the pairing process, it is recommended to check, and if needed update, the pump password. You can do this by going to the pump settings -> user settings -> password. The default password is 1234, if this is your password, please consider changing it"
           }
         },
@@ -4486,7 +4756,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Controleer vóór het koppelen het wachtwoord van de pomp en pas het indien nodig aan. Ga hiervoor naar de pompinstellingen, selecteer 'Gebruikersinstellingen' en vervolgens 'Wachtwoord'. Het standaardwachtwoord is 1234; als je dit nog gebruikt, overweeg dan om het te wijzigen."
+            "value" : "Voordat je begint met het koppelproces, is het aan te raden om het wachtwoord van de pomp te controleren en zo nodig bij te werken. Je kunt dit doen via de pompinstellingen -> gebruikersinstellingen -> wachtwoord. Het standaard wachtwoord is 1234. Als dit je wachtwoord is, overweeg dan om het te wijzigen."
           }
         },
         "pl" : {
@@ -4566,10 +4836,16 @@
             "value" : "قياس نسبة الجلوكوز في الدم"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Měření glukózy v krvi"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Blodsukkermåling"
+            "value" : "Måling af blodsukker"
           }
         },
         "de" : {
@@ -4598,7 +4874,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Blood glucose Measure"
           }
         },
@@ -4700,7 +4976,13 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الجرعة"
+            "value" : "بولوس"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolus"
           }
         },
         "da" : {
@@ -4724,7 +5006,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lisäannos"
+            "value" : "Bolus"
           }
         },
         "fr" : {
@@ -4735,7 +5017,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Bolus"
           }
         },
@@ -4840,10 +5122,16 @@
             "value" : "كلاهما"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obě stránky"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Begge"
+            "value" : "Begge dele"
           }
         },
         "de" : {
@@ -4872,7 +5160,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Both"
           }
         },
@@ -4977,6 +5265,12 @@
             "value" : "إلغاء"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zrušit"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4998,7 +5292,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Peru"
+            "value" : "Peruuta"
           }
         },
         "fr" : {
@@ -5009,8 +5303,14 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Cancel"
+          }
+        },
+        "hi" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "निरस्त"
           }
         },
         "hu" : {
@@ -5022,7 +5322,19 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cancella"
+            "value" : "Annulla"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "キャンセル"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avbryt"
           }
         },
         "nb-NO" : {
@@ -5034,7 +5346,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Annuleer"
+            "value" : "Annuleren"
           }
         },
         "pl" : {
@@ -5053,6 +5365,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cancelar"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cancelar"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Renunță"
           }
         },
         "ru" : {
@@ -5076,7 +5400,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vazgeç"
+            "value" : "İptal"
           }
         },
         "uk" : {
@@ -5114,10 +5438,16 @@
             "value" : "عمر القنية"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stáří kanyly"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kanylealder"
+            "value" : "Kanylens alder"
           }
         },
         "de" : {
@@ -5146,7 +5476,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Cannula age"
           }
         },
@@ -5251,6 +5581,12 @@
             "value" : "قنية فقط"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pouze kanyla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5283,7 +5619,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Cannula only"
           }
         },
@@ -5389,10 +5725,16 @@
             "value" : "إعادة تعبئة القنية"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doplnění kanyly"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kanylegenopfyldning"
+            "value" : "Genopfyldning af kanyle"
           }
         },
         "de" : {
@@ -5427,7 +5769,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Cannula refill"
           }
         },
@@ -5532,6 +5874,12 @@
             "value" : "شيك شافت"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zkontrolujte řetěz"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5564,7 +5912,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Check chaft"
           }
         },
@@ -5669,6 +6017,12 @@
             "value" : "افحص المضخة وحاول مرة أخرى"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zkontrolujte čerpadlo a zkuste to znovu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5701,7 +6055,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Check the pump and try again"
           }
         },
@@ -5806,6 +6160,12 @@
             "value" : "افحص الخزان والحقن وحاول مرة أخرى"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zkontrolujte zásobník a infuzi a zkuste to znovu."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5838,7 +6198,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Check the reservoir and infus and try again"
           }
         },
@@ -5943,10 +6303,16 @@
             "value" : "تم الفحص في"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zkontrolováno v"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tjekket kl."
+            "value" : "Kontrolleret på"
           }
         },
         "de" : {
@@ -5975,7 +6341,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Checked at"
           }
         },
@@ -6000,7 +6366,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gecontroleerd bij"
+            "value" : "Gecontroleerd op"
           }
         },
         "pl" : {
@@ -6080,10 +6446,16 @@
             "value" : "فشلت عملية الفحص. حاول مرة أخرى"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontrolní součet selhal. Zkuste to znovu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ukorrekt kontrolsum. Forsøg igen"
+            "value" : "Checksum mislykkedes. Prøv igen"
           }
         },
         "de" : {
@@ -6112,7 +6484,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Checksum failed. Try again"
           }
         },
@@ -6214,7 +6586,13 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ضبط"
+            "value" : "التكوين"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurace"
           }
         },
         "da" : {
@@ -6237,8 +6615,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Configuration"
+            "state" : "translated",
+            "value" : "Konfigurointi"
           }
         },
         "fr" : {
@@ -6249,7 +6627,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Configuration"
           }
         },
@@ -6274,7 +6652,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Instellingen"
+            "value" : "Configuratie"
           }
         },
         "pl" : {
@@ -6486,8 +6864,14 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Connected"
+            "state" : "translated",
+            "value" : "متصل"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Připojeno"
           }
         },
         "da" : {
@@ -6523,7 +6907,7 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "מחובר"
+            "value" : "Connected"
           }
         },
         "hu" : {
@@ -6547,7 +6931,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verbonden"
+            "value" : "Aangesloten"
           }
         },
         "pl" : {
@@ -6623,20 +7007,26 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Connecting"
+            "state" : "translated",
+            "value" : "التوصيل"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Připojení"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tilslutter"
+            "value" : "Forbindelse"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verbinden"
+            "value" : "Verbinden Sie"
           }
         },
         "es" : {
@@ -6648,19 +7038,19 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Yhdistetään"
+            "value" : "Yhdistäminen"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Connexion en cours"
+            "value" : "Connexion"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "מתחבר"
+            "value" : "Connecting"
           }
         },
         "hu" : {
@@ -6675,6 +7065,12 @@
             "value" : "In fase di Connessione"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tilkobling"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6684,7 +7080,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bezig met verbinden"
+            "value" : "Aansluiten op"
           }
         },
         "pl" : {
@@ -6750,7 +7146,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "正在连接"
+            "value" : "连接"
           }
         }
       }
@@ -6764,6 +7160,12 @@
             "value" : "تابع"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pokračovat"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6773,7 +7175,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fortsetzen"
+            "value" : "Weiter"
           }
         },
         "es" : {
@@ -6796,7 +7198,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Continue"
           }
         },
@@ -6812,6 +7214,12 @@
             "value" : "Continua"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fortsett"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6821,7 +7229,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vervolg"
+            "value" : "Ga verder"
           }
         },
         "pl" : {
@@ -6901,6 +7309,12 @@
             "value" : "تم الوصول إلى الحد اليومي"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dosažení denního limitu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6933,7 +7347,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Daily limit reached"
           }
         },
@@ -6947,6 +7361,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Limite giornaliero raggiunto"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Daglig grense nådd"
           }
         },
         "nb-NO" : {
@@ -7035,6 +7455,12 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
+            "value" : "دانا-أنا"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Dana-i"
           }
         },
@@ -7058,19 +7484,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Dana-i"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Dana-i"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Dana-i"
           }
         },
@@ -7081,6 +7507,12 @@
           }
         },
         "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dana-i"
+          }
+        },
+        "nb" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dana-i"
@@ -7175,6 +7607,12 @@
             "value" : "إعداد Dana-i/RS"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nastavení systému Dana-i/RS"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7207,7 +7645,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Dana-i/RS Setup"
           }
         },
@@ -7221,6 +7659,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Configurazione di Dana-i/RS"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dana-i/RS-oppsett"
           }
         },
         "nb-NO" : {
@@ -7312,6 +7756,12 @@
             "value" : "تم العثور على Dana-RS v3!"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dana-RS v3 nalezen!"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7344,7 +7794,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Dana-RS v3 found!"
           }
         },
@@ -7358,6 +7808,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dana-RS v3 trovato!"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dana-RS v3 funnet!"
           }
         },
         "nb-NO" : {
@@ -7449,6 +7905,12 @@
             "value" : "DanaRS-v1"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DanaRS-v1"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7469,19 +7931,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v1"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v1"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v1"
           }
         },
@@ -7492,6 +7954,12 @@
           }
         },
         "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DanaRS-v1"
+          }
+        },
+        "nb" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "DanaRS-v1"
@@ -7571,7 +8039,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v1"
           }
         }
@@ -7586,6 +8054,12 @@
             "value" : "DanaRS-v3"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DanaRS-v3"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7606,19 +8080,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v3"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v3"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v3"
           }
         },
@@ -7629,6 +8103,12 @@
           }
         },
         "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DanaRS-v3"
+          }
+        },
+        "nb" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "DanaRS-v3"
@@ -7708,7 +8188,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v3"
           }
         }
@@ -7722,6 +8202,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "يوم (أيام)"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "den(y)"
           }
         },
         "da" : {
@@ -7762,7 +8248,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "day(s)"
           }
         },
@@ -7775,7 +8261,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "giorno/i"
+            "value" : "U/giorno"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "dag(er)"
           }
         },
         "nb-NO" : {
@@ -7914,6 +8406,12 @@
             "value" : "DEBUG: Bolus action"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG: Bolus-handling"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7989,7 +8487,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "调试：追加胰岛素操作"
+            "value" : "调试：大剂量操作"
           }
         }
       }
@@ -8048,6 +8546,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "DEBUG: Temp basal action"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEBUG: Midlertidig basal handling"
           }
         },
         "nb-NO" : {
@@ -8139,10 +8643,16 @@
             "value" : "حذف المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odstranit čerpadlo"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Slet pumpe"
+            "value" : "Slet pumpen"
           }
         },
         "de" : {
@@ -8171,7 +8681,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Delete pump"
           }
         },
@@ -8185,6 +8695,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Eliminare la pompa"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slett pumpe"
           }
         },
         "nb-NO" : {
@@ -8276,6 +8792,12 @@
             "value" : "حذف المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odstranit čerpadlo"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8308,7 +8830,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Delete Pump"
           }
         },
@@ -8324,6 +8846,12 @@
             "value" : "Cancella Microinfusore"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slette pumpe"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8333,7 +8861,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verwijder de pomp"
+            "value" : "Pomp verwijderen"
           }
         },
         "pl" : {
@@ -8413,6 +8941,12 @@
             "value" : "سرعة التوصيل"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rychlost dodání"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8445,7 +8979,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Delivery speed"
           }
         },
@@ -8459,6 +8993,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Velocità di consegna"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Leveringshastighet"
           }
         },
         "nb-NO" : {
@@ -8597,6 +9137,12 @@
             "value" : "Device found!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Enhet funnet!"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8687,10 +9233,16 @@
             "value" : "تعطيل مزامنة البلعة؟"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zakázat synchronizaci bolusu?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Deaktivér bolus-synkning?"
+            "value" : "Deaktivere bolus-synkronisering?"
           }
         },
         "de" : {
@@ -8725,7 +9277,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disable bolus syncing?"
           }
         },
@@ -8739,6 +9291,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Disattivare la sincronizzazione del bolo?"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deaktiver bolussynkronisering?"
           }
         },
         "nb-NO" : {
@@ -8816,7 +9374,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "禁用栓剂同步？"
+            "value" : "禁用追加胰岛素同步？"
           }
         }
       }
@@ -8875,6 +9433,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Disconnect"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koble fra"
           }
         },
         "nb-NO" : {
@@ -8951,8 +9515,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Disconnect"
+            "state" : "translated",
+            "value" : "断开连接"
           }
         }
       }
@@ -8966,10 +9530,16 @@
             "value" : "قطع الاتصال بالمضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odpojení od čerpadla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Frakobl fra pumpen"
+            "value" : "Afbryd forbindelsen til pumpen"
           }
         },
         "de" : {
@@ -8998,7 +9568,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnect from pump"
           }
         },
@@ -9012,6 +9582,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Scollegare dalla pompa"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koble fra pumpen"
           }
         },
         "nb-NO" : {
@@ -9099,8 +9675,14 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Disconnected"
+            "state" : "translated",
+            "value" : "غير متصل"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odpojení"
           }
         },
         "da" : {
@@ -9124,7 +9706,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ei yhteydessä"
+            "value" : "Irrotettu"
           }
         },
         "fr" : {
@@ -9136,7 +9718,7 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "מנותק"
+            "value" : "Disconnected"
           }
         },
         "hu" : {
@@ -9149,6 +9731,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Disconnesso"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Frakoblet"
           }
         },
         "nb-NO" : {
@@ -9226,7 +9814,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已断开连接"
+            "value" : "断开"
           }
         }
       }
@@ -9238,6 +9826,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "قطع الاتصال..."
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odpojení..."
           }
         },
         "da" : {
@@ -9272,7 +9866,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnecting..."
           }
         },
@@ -9286,6 +9880,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Disconnessione..."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kobler fra..."
           }
         },
         "nb-NO" : {
@@ -9424,6 +10024,12 @@
             "value" : "Do bolus"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gjør bolus"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9499,7 +10105,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "执行追加胰岛素"
+            "value" : "执行大剂量推注"
           }
         }
       }
@@ -9511,6 +10117,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "هل ترغب في تلقي إشعار عندما تكون المضخة مفصولة لفترة زمنية محددة؟"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chcete dostávat upozornění, když je čerpadlo delší dobu odpojeno?"
           }
         },
         "da" : {
@@ -9545,7 +10157,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do you wish to receive a notification when the pump is longer disconnected for a specific time?"
           }
         },
@@ -9559,6 +10171,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Si desidera ricevere una notifica quando la pompa viene scollegata per un periodo di tempo specifico?"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ønsker du å motta et varsel når pumpen ikke lenger er koblet fra i en bestemt periode?"
           }
         },
         "nb-NO" : {
@@ -9697,6 +10315,12 @@
             "value" : "Fine"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ferdig"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9786,10 +10410,16 @@
             "value" : "أثناء عملية الاقتران، سيعرض جهاز Dana-i الخاص بك مطالبة بالاقتران بينما سيعرض جهاز iPhone الخاص بك مطالبة برمز الاقتران. عند قيامك بالضخ، حدد موافق واكتب الرمز المكون من 6 أرقام في شاشة جهاز الآيفون الخاص بك. بعد ذلك، يكون %1$@ جاهزًا للتواصل مع جهاز Dana-i الخاص بك"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Během procesu párování se na displeji zařízení Dana-i zobrazí výzva ke spárování, zatímco na displeji iPhonu se zobrazí výzva k zadání párovacího kódu. Na pumpě zvolte OK a zadejte šestimístný kód na obrazovce iPhonu. Poté je stránka %1$@ připravena komunikovat s vaším zařízením Dana-i."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dana-i vil under parringsprocessen vil vise en parringsprompt, mens iPhonen vil vise en prompt om en parringskode. Vælg OK på pumpen, og angiv den 6-cifrede kode på skærmen på iPhonen. %1$@ vil herefter være klar til at kommunikere med Dana-i"
+            "value" : "Under parringsprocessen vil din Dana-i vise en parringsmeddelelse, mens din iPhone vil vise en meddelelse om en parringskode. Vælg OK på din pumpe, og skriv den 6-cifrede kode på skærmen på din iPhone. Herefter er %1$@ klar til at kommunikere med din Dana-i."
           }
         },
         "de" : {
@@ -9818,7 +10448,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your Dana-i will show a pairing prompt while your iPhone will show a prompt for a pairing code. On you pump, select OK and type the 6-digit code in screen on your iPhone. After that, %1$@ is ready to communicate with your Dana-i"
           }
         },
@@ -9832,6 +10462,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Durante il processo di accoppiamento, il Dana-i mostrerà una richiesta di accoppiamento, mentre l'iPhone mostrerà una richiesta di codice di accoppiamento. Selezionare OK e digitare il codice di 6 cifre sullo schermo dell'iPhone. A questo punto, %1$@ è pronto a comunicare con il vostro Dana-i."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Under sammenkoblingsprosessen vil Dana-i vise en sammenkoblingsmelding mens iPhone vil vise en melding om en sammenkoblingskode. På pumpen velger du OK og skriver inn den 6-sifrede koden på skjermen på iPhone. Deretter %1$@ er klar til å kommunisere med din Dana-i"
           }
         },
         "nb-NO" : {
@@ -9971,6 +10607,12 @@
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Under sammenkoblingsprosessen vil DanaRS v1 vise en sammenkoblingsmelding, mens iPhone vil vise en melding om en sammenkoblingskode. Velg OK på pumpen, og skriv inn koden på iPhone. Etter dette er %1$@ klar til å kommunisere med DanaRS v1"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "new",
@@ -10045,8 +10687,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+            "state" : "translated",
+            "value" : "在配对过程中，你的 DanaRS v1 胰岛素泵会显示一个配对提示，而你的 iPhone 会弹出输入配对码的提示。在胰岛素泵上选择“确定”，然后在 iPhone 上输入该配对码。完成后，%1$@ 将准备好与 DanaRS v1 通讯。"
           }
         }
       }
@@ -10099,7 +10741,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
@@ -10113,6 +10755,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Durante il processo di accoppiamento, il DanaRS v1 mostrerà una richiesta di accoppiamento, mentre l'iPhone mostrerà una richiesta di codice di accoppiamento. Sulla pompa, selezionare OK e digitare il codice sull'iPhone. Dopodiché, Loop è pronto a comunicare con il DanaRS v1."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Under sammenkoblingsprosessen vil DanaRS v1 vise en sammenkoblingsmelding, mens iPhone vil vise en melding om en sammenkoblingskode. Velg OK på pumpen, og skriv inn koden på iPhone. Etter dette er Loop klar til å kommunisere med DanaRS v1"
           }
         },
         "nb-NO" : {
@@ -10205,6 +10853,12 @@
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Během procesu párování se na displeji zařízení DanaRS v3 zobrazí výzva ke spárování, zatímco na displeji iPhonu se zobrazí výzva k zadání párovacího kódu. Na pumpě vyberte OK a zadejte kód na iPhonu. Poté je zařízení Loop připraveno ke komunikaci s vaším zařízením DanaRS v1."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "new",
@@ -10251,6 +10905,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Under sammenkoblingsprosessen vil DanaRS v3 vise en sammenkoblingsmelding, mens iPhone vil vise en melding om en sammenkoblingskode. Velg OK på pumpen, og skriv inn koden på iPhone. Etter dette er Loop klar til å kommunisere med DanaRS v1"
           }
         },
         "nb-NO" : {
@@ -10390,6 +11050,12 @@
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Under sammenkoblingsprosessen vil DanaRS v3 vise en sammenkoblingsmelding, mens iPhone vil vise en melding om to sammenkoblingskoder. Velg OK på pumpen, og skriv inn de to kodene på iPhone. Etter dette er %1$@ klar til å kommunisere med DanaRS v3"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "new",
@@ -10464,8 +11130,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+            "state" : "translated",
+            "value" : "在配对过程中，你的 DanaRS v3 胰岛素泵会显示一个配对提示，而你的 iPhone 会显示两个配对码的输入框。在胰岛素泵上选择“确定”，然后在 iPhone 上输入这两个配对码。完成后，%1$@ 将准备好与 DanaRS v3 通讯。"
           }
         }
       }
@@ -10478,6 +11144,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "أثناء عملية الاقتران، ستظهر لك مضخة DanaRS v3 مطالبة بالاقتران بينما سيظهر لك جهاز iPhone مطالبة برمزي اقتران. على المضخة الخاصة بك، حدد موافق واكتب الرمزين على جهاز iPhone الخاص بك. بعد ذلك، تصبح Loop جاهزة للتواصل مع جهاز DanaRS v3 الخاص بك"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Během procesu párování se na displeji zařízení DanaRS v3 zobrazí výzva ke spárování, zatímco na displeji iPhonu se zobrazí výzva k zadání dvou párovacích kódů. Na pumpě vyberte OK a zadejte dva kódy na iPhonu. Poté je zařízení Loop připraveno ke komunikaci s vaším zařízením DanaRS v3."
           }
         },
         "da" : {
@@ -10518,7 +11190,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3"
           }
         },
@@ -10532,6 +11204,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Durante il processo di accoppiamento, il DanaRS v3 mostrerà una richiesta di accoppiamento, mentre l'iPhone mostrerà una richiesta di due codici di accoppiamento. Sulla pompa, selezionare OK e digitare i due codici sull'iPhone. Dopodiché, Loop è pronto a comunicare con il DanaRS v3."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Under sammenkoblingsprosessen vil DanaRS v3 vise en sammenkoblingsmelding, mens iPhone vil vise en melding om to sammenkoblingskoder. Velg OK på pumpen, og skriv inn de to kodene på iPhone. Etter dette er Loop klar til å kommunisere med DanaRS v3"
           }
         },
         "nb-NO" : {
@@ -10620,19 +11298,25 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الخزان فارغ"
+            "value" : "خزان فارغ"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prázdná nádrž"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tomt reservoir"
+            "value" : "Tøm reservoiret"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reservoir leer"
+            "value" : "Behälter entleeren"
           }
         },
         "es" : {
@@ -10644,7 +11328,7 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Säiliö tyhjä"
+            "value" : "Tyhjä säiliö"
           }
         },
         "fr" : {
@@ -10655,7 +11339,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Empty reservoir"
           }
         },
@@ -10680,7 +11364,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reservoir leeg"
+            "value" : "Leeg reservoir"
           }
         },
         "pl" : {
@@ -10746,7 +11430,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "胰岛素储量为零"
+            "value" : "空水库"
           }
         }
       }
@@ -10758,6 +11442,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "خطأ أثناء الاتصال بالجهاز"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chyba při připojování k zařízení"
           }
         },
         "da" : {
@@ -10792,7 +11482,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while connecting to device"
           }
         },
@@ -11033,10 +11723,16 @@
             "value" : "خطأ: فشل في إقران الجهاز"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "CHYBA: Nepodařilo se spárovat zařízení"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "FEJL: Mislykkedes at parre enhed"
+            "value" : "FEJL: Kunne ikke parre enheden"
           }
         },
         "de" : {
@@ -11065,7 +11761,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "ERROR: Failed to pair device"
           }
         },
@@ -11079,6 +11775,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ERRORE: Impossibile accoppiare il dispositivo"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "FEIL: Kunne ikke koble sammen enheten"
           }
         },
         "nb-NO" : {
@@ -11170,6 +11872,12 @@
             "value" : "فشل في ضبط القاعدة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nepodařilo se upravit bazální"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11202,7 +11910,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to adjust basal"
           }
         },
@@ -11307,6 +12015,12 @@
             "value" : "فشل في ضبط وقت المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nepodařilo se nastavit čas čerpadla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11339,7 +12053,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to adjust pump time"
           }
         },
@@ -11444,6 +12158,12 @@
             "value" : "فشل في ضبط التعليق"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nepodařilo se nastavit odpružení"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11476,7 +12196,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to adjust suspension"
           }
         },
@@ -11582,6 +12302,12 @@
             "value" : "فشل في ضبط درجة الحرارة القاعدية"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nepodařilo se nastavit bazální teplotu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11620,7 +12346,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to adjust temp basal"
           }
         },
@@ -11725,10 +12451,16 @@
             "value" : "فشل في إنشاء برنامج دانا بازل"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nepodařilo se vygenerovat základní program Dana"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Kunne ikke generere Dana-basalprogram"
+            "value" : "Kunne ikke generere Dana basalprogram"
           }
         },
         "de" : {
@@ -11757,7 +12489,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to generate Dana basal program"
           }
         },
@@ -11863,6 +12595,12 @@
             "value" : "فشل في إجراء اتصال"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nepodařilo se navázat spojení"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11901,7 +12639,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to make a connection"
           }
         },
@@ -12146,7 +12884,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mislykkedes at spæde kanyle. Forsøg igen senere"
+            "value" : "Kanylen blev ikke primet. Prøv venligst igen senere"
           }
         },
         "de" : {
@@ -12175,7 +12913,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to prime the cannula. Please try again later"
           }
         },
@@ -12283,7 +13021,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mislykkedes at spæde slange. Forsøg igen senere"
+            "value" : "Det lykkedes ikke at prime slangen. Prøv venligst igen senere"
           }
         },
         "de" : {
@@ -12312,7 +13050,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to prime the tube. Please try again later"
           }
         },
@@ -12420,7 +13158,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Mislykkedes at indstille reservoirmængde. Gensynk pumpedata, og forsøg igen"
+            "value" : "Det lykkedes ikke at indstille reservoirmængden. Synkroniser pumpedata igen, og prøv igen."
           }
         },
         "de" : {
@@ -12449,7 +13187,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to set reservoir amount. Re-sync pump data and try again please"
           }
         },
@@ -12554,6 +13292,12 @@
             "value" : "أدخل كلمة المرور"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vyplňte heslo"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12586,7 +13330,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Fill in password"
           }
         },
@@ -12691,6 +13435,12 @@
             "value" : "الإنهاء"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dokončení"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12723,7 +13473,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Finish"
           }
         },
@@ -12828,6 +13578,12 @@
             "value" : "إصدار البرنامج الثابت"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verze firmwaru"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12860,7 +13616,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Firmware version"
           }
         },
@@ -12965,10 +13721,16 @@
             "value" : "وجدت مضخات Dana-i/RS"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nalezená čerpadla Dana-i/RS"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dana-i/RS-pumper fundet"
+            "value" : "Fandt Dana-i/RS-pumper"
           }
         },
         "de" : {
@@ -12997,7 +13759,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Found Dana-i/RS pumps"
           }
         },
@@ -13102,6 +13864,12 @@
             "value" : "طراز الأجهزة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hardwarový model"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13134,7 +13902,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Hardware model"
           }
         },
@@ -13239,6 +14007,12 @@
             "value" : "الأنسولين\nمعلق"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inzulín\nPozastaveno"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13271,7 +14045,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin\nSuspended"
           }
         },
@@ -13285,6 +14059,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulina \nSospesa"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insulin\n Suspendert"
           }
         },
         "nb-NO" : {
@@ -13376,10 +14156,16 @@
             "value" : "توصيل الأنسولين"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dodávka inzulínu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulintilførsel"
+            "value" : "Levering af insulin"
           }
         },
         "de" : {
@@ -13396,19 +14182,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Delivery"
+            "state" : "translated",
+            "value" : "Insuliinin toimitus"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Administration de l'insuline"
+            "value" : "Administration d'insuline"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin Delivery"
           }
         },
@@ -13499,7 +14285,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "胰岛素输注"
+            "value" : "胰岛素输送"
           }
         }
       }
@@ -13513,10 +14299,16 @@
             "value" : "الأنسولين المتبقي"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zbývající inzulín"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Resterende Insulin"
+            "value" : "Resterende insulin"
           }
         },
         "de" : {
@@ -13533,8 +14325,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Remaining"
+            "state" : "translated",
+            "value" : "Jäljellä oleva insuliini"
           }
         },
         "fr" : {
@@ -13545,7 +14337,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin Remaining"
           }
         },
@@ -13636,7 +14428,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "胰岛素余量"
+            "value" : "胰岛素剩余量"
           }
         }
       }
@@ -13646,8 +14438,14 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Suspended"
+            "state" : "translated",
+            "value" : "تعليق الأنسولين"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozastavení podávání inzulínu"
           }
         },
         "da" : {
@@ -13659,7 +14457,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin ausgesetzt"
+            "value" : "Insulin suspendiert"
           }
         },
         "es" : {
@@ -13670,19 +14468,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Suspended"
+            "state" : "translated",
+            "value" : "Insuliini keskeytetty"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insuline suspendue"
+            "value" : "Suspension de l'insuline"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin Suspended"
           }
         },
@@ -13707,7 +14505,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insuline tijdelijk uitgeschakeld"
+            "value" : "Insuline Opgeschort"
           }
         },
         "pl" : {
@@ -13772,8 +14570,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Suspended"
+            "state" : "translated",
+            "value" : "胰岛素停用"
           }
         }
       }
@@ -13784,13 +14582,19 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "نوع الإنسولين"
+            "value" : "نوع الأنسولين"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Typ inzulínu"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulintype"
+            "value" : "Insulin-type"
           }
         },
         "de" : {
@@ -13807,19 +14611,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Type"
+            "state" : "translated",
+            "value" : "Insuliinityyppi"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Type d'Insuline"
+            "value" : "Type d'insuline"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin Type"
           }
         },
@@ -13844,7 +14648,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulinesoort"
+            "value" : "Type insuline"
           }
         },
         "pl" : {
@@ -13924,10 +14728,16 @@
             "value" : "آخر مزامنة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poslední synchronizace"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Senete synk"
+            "value" : "Sidste synkronisering"
           }
         },
         "de" : {
@@ -13956,7 +14766,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Last sync"
           }
         },
@@ -14061,10 +14871,16 @@
             "value" : "شاشة LCD في الوقت المحدد"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lcd na čas"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LCD på tidspunktet"
+            "value" : "Lcd på tid"
           }
         },
         "de" : {
@@ -14087,13 +14903,13 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Lcd on time"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Lcd on time"
           }
         },
@@ -14118,7 +14934,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lcd op tijd"
+            "value" : "Lcd aan tijd"
           }
         },
         "pl" : {
@@ -14196,13 +15012,19 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "جاري التحميل"
+            "value" : "التحميل"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "nakládání"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "indlæser"
+            "value" : "Indlæsning"
           }
         },
         "de" : {
@@ -14237,7 +15059,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "loading"
           }
         },
@@ -14250,7 +15072,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "caricamento"
+            "value" : "Caricamento..."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laster"
           }
         },
         "nb-NO" : {
@@ -14328,7 +15156,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "装载量"
+            "value" : "加载中"
           }
         }
       }
@@ -14343,10 +15171,16 @@
             "value" : "التحميل"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Načítání"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indlæser"
+            "value" : "Indlæsning"
           }
         },
         "de" : {
@@ -14381,7 +15215,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Loading"
           }
         },
@@ -14395,6 +15229,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Caricamento"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Laster"
           }
         },
         "nb-NO" : {
@@ -14486,6 +15326,12 @@
             "value" : "انخفاض بطارية المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vybitá baterie čerpadla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14518,7 +15364,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Low pump battery"
           }
         },
@@ -14532,6 +15378,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Batteria della pompa scarica"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lavt batteri i pumpen"
           }
         },
         "nb-NO" : {
@@ -14623,10 +15475,16 @@
             "value" : "تذكير بانخفاض مستوى الخزان"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Připomenutí nízké hladiny v nádrži"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lavt reservoir-påmindelse"
+            "value" : "Påmindelse om lav reservoirbeholdning"
           }
         },
         "de" : {
@@ -14655,7 +15513,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Low reservoir reminder"
           }
         },
@@ -14669,6 +15527,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Segnalazione del serbatoio basso"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Påminnelse om lavt reservoar"
           }
         },
         "nb-NO" : {
@@ -14760,10 +15624,16 @@
             "value" : "مزامنة وقت المضخة يدوياً"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ruční synchronizace času čerpadla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synk pumpetid manuelt"
+            "value" : "Synkroniser pumpetiden manuelt"
           }
         },
         "de" : {
@@ -14792,7 +15662,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Manually sync Pump time"
           }
         },
@@ -14806,6 +15676,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sincronizzazione manuale dell'ora della pompa"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synkroniser pumpetiden manuelt"
           }
         },
         "nb-NO" : {
@@ -14897,10 +15773,16 @@
             "value" : "فحص جلوكوز الدم الفائت"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zmeškaná kontrola glykémie"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Missede blodsukkermåling"
+            "value" : "Udeblevet blodsukkermåling"
           }
         },
         "de" : {
@@ -14929,7 +15811,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Missed Blood glucose check"
           }
         },
@@ -14943,6 +15825,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mancato controllo della glicemia"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mistet blodsukkermåling"
           }
         },
         "nb-NO" : {
@@ -15034,10 +15922,16 @@
             "value" : "مزامنة وقت الضخ ليلاً"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Noční synchronizace času čerpadla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Natlig synk af pumpetid"
+            "value" : "Natlig synkronisering af pumpetid"
           }
         },
         "de" : {
@@ -15066,7 +15960,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Nightly pump time sync"
           }
         },
@@ -15080,6 +15974,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sincronizzazione notturna del tempo di pompaggio"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synkronisering av pumpetid om natten"
           }
         },
         "nb-NO" : {
@@ -15218,6 +16118,12 @@
             "value" : "No"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nei"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15292,8 +16198,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No"
+            "state" : "translated",
+            "value" : "不"
           }
         }
       }
@@ -15304,7 +16210,13 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "لا يوجد إنسولين"
+            "value" : "لا أنسولين"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Žádný inzulín"
           }
         },
         "da" : {
@@ -15327,8 +16239,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No Insulin"
+            "state" : "translated",
+            "value" : "Ei insuliinia"
           }
         },
         "fr" : {
@@ -15339,7 +16251,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "No Insulin"
           }
         },
@@ -15352,7 +16264,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nessuna Insulina"
+            "value" : "Insulina esaurita"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ingen insulin"
           }
         },
         "nb-NO" : {
@@ -15369,8 +16287,8 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No Insulin"
+            "state" : "translated",
+            "value" : "Brak insuliny"
           }
         },
         "pt" : {
@@ -15383,6 +16301,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "No Insulin"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fără insulină"
           }
         },
         "ru" : {
@@ -15406,7 +16330,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "İnsülin Yok"
+            "value" : "İnsülin yok"
           }
         },
         "uk" : {
@@ -15429,8 +16353,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No Insulin"
+            "state" : "translated",
+            "value" : "无胰岛素"
           }
         }
       }
@@ -15444,10 +16368,16 @@
             "value" : "لا، فقط افصل الاتصال"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ne, jen se odpojte"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nej, bare frakobl"
+            "value" : "Nej, bare afbryd forbindelsen"
           }
         },
         "de" : {
@@ -15476,7 +16406,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "No, just disconnect"
           }
         },
@@ -15490,6 +16420,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No, basta disconnettersi"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nei, bare koble fra"
           }
         },
         "nb-NO" : {
@@ -15581,6 +16517,12 @@
             "value" : "لا، احتفظ بها كما هي"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ne, ponechat ve stávajícím stavu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15613,7 +16555,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "No, Keep as is"
           }
         },
@@ -15627,6 +16569,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "No, conservare così com'è"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nei, behold som det er"
           }
         },
         "nb-NO" : {
@@ -15715,7 +16663,13 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "لا، إبقاء المضخة كما هي"
+            "value" : "لا، احتفظ بالمضخة كما هي"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ne, nechte čerpadlo tak, jak je"
           }
         },
         "da" : {
@@ -15727,7 +16681,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nein, Pumpe unverändert behalten"
+            "value" : "Nein, Pumpe so lassen wie sie ist"
           }
         },
         "es" : {
@@ -15738,19 +16692,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No, Keep Pump As Is"
+            "state" : "translated",
+            "value" : "Ei, pidä pumppu sellaisenaan"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Non, garder la pompe telle quelle"
+            "value" : "Non, conserver la pompe en l'état"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "No, Keep Pump As Is"
           }
         },
@@ -15766,6 +16720,12 @@
             "value" : "No, Tieni microinfusore Come È"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nei, behold pumpen som den er"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15775,7 +16735,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Nee, pomp laten zoals hij is"
+            "value" : "Nee, houd de pomp zoals hij is"
           }
         },
         "pl" : {
@@ -15840,8 +16800,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "No, Keep Pump As Is"
+            "state" : "translated",
+            "value" : "不，保持泵原样"
           }
         }
       }
@@ -15852,19 +16812,19 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ملاحظة: جهاز DanaRS v1 غير مدعوم (حالياً). إذا كان لديك مضخة DanaRS v1 متوفرة للاختبار، يُرجى التواصل مع Bastiaan Verhaar!"
+            "value" : "ملاحظة: مضخة DanaRS v1 غير مدعومة (حتى الآن). إذا كان لديك مضخة DanaRS v1 متاحة للاختبار، يُرجى الاتصال بباستيان فيرهاار!"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
+            "state" : "translated",
+            "value" : "BEMÆRK: DanaRS v1 understøttes ikke (endnu). Hvis du har en DanaRS v1-pumpe til rådighed til test, bedes du kontakte Bastiaan Verhaar!"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
+            "state" : "translated",
+            "value" : "HINWEIS: Die DanaRS v1 wird (noch) nicht unterstützt. Wenn Sie eine DanaRS v1 Pumpe zum Testen zur Verfügung haben, kontaktieren Sie bitte Bastiaan Verhaar!"
           }
         },
         "es" : {
@@ -15875,19 +16835,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
+            "state" : "translated",
+            "value" : "HUOMAUTUS: DanaRS v1 ei ole tuettu (vielä). Jos sinulla on DanaRS v1 -pumppu testattavana, ota yhteyttä Bastiaan Verhaariin!"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
+            "state" : "translated",
+            "value" : "NOTE : Le DanaRS v1 n'est pas (encore) supporté. Si vous avez une pompe DanaRS v1 disponible pour des tests, veuillez contacter Bastiaan Verhaar !"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
@@ -15903,6 +16863,12 @@
             "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MERK: DanaRS v1 støttes ikke (ennå). Hvis du har en DanaRS v1-pumpe tilgjengelig for testing, vennligst kontakt Bastiaan Verhaar!"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "new",
@@ -15912,7 +16878,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "LET OP: De DanaRS v1 wordt (nog) niet ondersteund. Heb je een DanaRS v1 pomp beschikbaar om mee te testen? Neem dan contact op met Bastiaan Verhaar!"
+            "value" : "LET OP: De DanaRS v1 wordt (nog) niet ondersteund. Als je een DanaRS v1 pomp beschikbaar hebt om te testen, neem dan contact op met Bastiaan Verhaar!"
           }
         },
         "pl" : {
@@ -15977,8 +16943,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
+            "state" : "translated",
+            "value" : "注意： 目前尚不支持 DanaRS v1。如果您有 DanaRS v1 泵可供测试，请联系 Bastiaan Verhaar！"
           }
         }
       }
@@ -15992,10 +16958,16 @@
             "value" : "ملاحظة: تحتوي مضخة دانا الخاصة بك على إعداد خاص يسمح لك بإسكات صوت تنبيه مضخة دانا. لتفعيل هذا الإعداد، يرجى الاتصال بموزع دانا الخاص بك"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Poznámka: Čerpadlo Dana má speciální nastavení, které umožňuje ztišit zvukové signály čerpadla Dana. Chcete-li toto nastavení povolit, obraťte se na svého distributora Dana."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bemærk: Dana-pumpen har en særlig indstilling, der kan tavsgøre Dana-pumpens bip. Kontakt Dana-distributøren for at aktivere dette"
+            "value" : "Bemærk: Din Dana-pumpe har en særlig indstilling, som gør det muligt at dæmpe Dana-pumpens bip. Kontakt din Dana-distributør for at aktivere dette."
           }
         },
         "de" : {
@@ -16024,7 +16996,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Note: You Dana pump has a special setting which allows you to silence your Dana pump beeps. To enable this, please contact your Dana distributor"
           }
         },
@@ -16038,6 +17010,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nota: la pompa Dana dispone di un'impostazione speciale che consente di silenziare i segnali acustici della pompa Dana. Per attivarla, contattare il proprio distributore Dana."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Merk: Dana-pumpen har en spesiell innstilling som gjør at du kan dempe pipelyden i Dana-pumpen. Kontakt Dana-distributøren din for å aktivere dette"
           }
         },
         "nb-NO" : {
@@ -16129,6 +17107,12 @@
             "value" : "الانسداد"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Okluze"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16149,19 +17133,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Occlusion"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Occlusion"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Occlusion"
           }
         },
@@ -16175,6 +17159,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Occlusione"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Okklusjon"
           }
         },
         "nb-NO" : {
@@ -16262,14 +17252,20 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Off"
+            "state" : "translated",
+            "value" : "إيقاف التشغيل"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vypnuto"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Slukket"
+            "value" : "Fra"
           }
         },
         "de" : {
@@ -16287,19 +17283,19 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pois päältä"
+            "value" : "Off"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Désactivé"
+            "value" : "Arrêt"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "כבוי"
+            "value" : "Off"
           }
         },
         "hu" : {
@@ -16312,6 +17308,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Spento"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Av"
           }
         },
         "nb-NO" : {
@@ -16388,8 +17390,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Off"
+            "state" : "translated",
+            "value" : "关闭"
           }
         }
       }
@@ -16401,6 +17403,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "حسناً"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
           }
         },
         "da" : {
@@ -16423,7 +17431,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "OK"
           }
         },
@@ -16435,7 +17443,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "OK"
           }
         },
@@ -16446,6 +17454,18 @@
           }
         },
         "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "nb" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
@@ -16465,7 +17485,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "OK"
           }
         },
@@ -16481,10 +17501,22 @@
             "value" : "OK"
           }
         },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "ОК"
+            "value" : "OK"
           }
         },
         "sk" : {
@@ -16526,7 +17558,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ok"
+            "value" : "好的"
           }
         }
       }
@@ -16673,14 +17705,20 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "On"
+            "state" : "translated",
+            "value" : "على"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Na adrese"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tændt"
+            "value" : "På"
           }
         },
         "de" : {
@@ -16698,19 +17736,19 @@
         "fi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Päällä"
+            "value" : "Osoitteessa"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Activé"
+            "value" : "Sur"
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "דולק"
+            "value" : "On"
           }
         },
         "hu" : {
@@ -16800,7 +17838,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "开"
+            "value" : "关于"
           }
         }
       }
@@ -16813,6 +17851,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "يتم دعم الجرعة التلقائية فقط"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podporován je pouze automatický bolus"
           }
         },
         "da" : {
@@ -16853,7 +17897,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Only Automatic Bolus is supported"
           }
         },
@@ -16944,7 +17988,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仅支持自动注射"
+            "value" : "仅支持自动推注大剂量"
           }
         }
       }
@@ -16956,6 +18000,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "كلمة السر DanaRS v1"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Heslo DanaRS v1"
           }
         },
         "da" : {
@@ -16990,7 +18040,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Password DanaRS v1"
           }
         },
@@ -17095,10 +18145,16 @@
             "value" : "الدبوس 1"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin 1"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PIN 1"
+            "value" : "Pin 1"
           }
         },
         "de" : {
@@ -17127,7 +18183,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pin 1"
           }
         },
@@ -17232,10 +18288,16 @@
             "value" : "الدبوس 2"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin 2"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PIN 2"
+            "value" : "Pin 2"
           }
         },
         "de" : {
@@ -17264,7 +18326,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pin 2"
           }
         },
@@ -17370,10 +18432,16 @@
             "value" : "الرمز البريدي مطلوب"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Požadovaný Pincode"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "PIN-kode kræves"
+            "value" : "Pinkode påkrævet"
           }
         },
         "de" : {
@@ -17408,7 +18476,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pincode required"
           }
         },
@@ -17514,10 +18582,16 @@
             "value" : "يُرجى التفكير في تغيير استراتيجية الجرعات في قائمة الإعدادات"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zvažte prosím změnu strategie dávkování v nabídce nastavení."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Overvej at ændre doseringsstrategien via indstillingsmenuen"
+            "value" : "Overvej at ændre din doseringsstrategi i indstillingsmenuen"
           }
         },
         "de" : {
@@ -17552,7 +18626,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Please consider changing your dosing strategy in the setting menu"
           }
         },
@@ -17643,7 +18717,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "请考虑在设置菜单中更改配料策略"
+            "value" : "请考虑在设置菜单中更改您的给药策略。"
           }
         }
       }
@@ -17794,6 +18868,12 @@
             "value" : "بطارية المضخة 0%"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baterie čerpadla 0%"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17826,7 +18906,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump battery 0%"
           }
         },
@@ -17932,10 +19012,16 @@
             "value" : "بطارية المضخة فارغة. استبدلها الآن!"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baterie čerpadla je vybitá. Okamžitě ji vyměňte!"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pumpebatteriet er tomt. Udskift det nu!"
+            "value" : "Pumpens batteri er tomt. Udskift det nu!"
           }
         },
         "de" : {
@@ -17970,7 +19056,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump battery is empty. Replace it now!"
           }
         },
@@ -18075,10 +19161,16 @@
             "value" : "يجب استبدال بطارية المضخة قريباً"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brzy je třeba vyměnit baterii čerpadla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pumpebatteriet skal snart udskiftes"
+            "value" : "Pumpens batteri skal snart udskiftes"
           }
         },
         "de" : {
@@ -18107,7 +19199,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump battery needs to be replaced soon"
           }
         },
@@ -18212,6 +19304,12 @@
             "value" : "خطأ في المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Chyba čerpadla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18244,7 +19342,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump error"
           }
         },
@@ -18349,10 +19447,16 @@
             "value" : "معلومات المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informace o čerpadle"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pumpeinformation"
+            "value" : "Information om pumpen"
           }
         },
         "de" : {
@@ -18381,7 +19485,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump information"
           }
         },
@@ -18623,6 +19727,12 @@
             "value" : "لا تزال المضخة مفصولة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Čerpadlo je stále odpojeno"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18655,7 +19765,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is still disconnected"
           }
         },
@@ -18760,10 +19870,16 @@
             "value" : "اسم المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Název čerpadla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pumpenavn"
+            "value" : "Pumpens navn"
           }
         },
         "de" : {
@@ -18792,7 +19908,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump name"
           }
         },
@@ -18897,6 +20013,12 @@
             "value" : "إيقاف تشغيل المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vypnutí čerpadla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18929,7 +20051,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump shutdown"
           }
         },
@@ -19034,6 +20156,12 @@
             "value" : "وقت المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doba čerpání"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19066,7 +20194,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump time"
           }
         },
@@ -19172,10 +20300,16 @@
             "value" : "إعادة تمكين مزامنة البلعة؟"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Znovu povolit synchronizaci bolusu?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Genaktivér bolus-synkning?"
+            "value" : "Genaktiver bolus-synkronisering?"
           }
         },
         "de" : {
@@ -19210,7 +20344,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Re-enable bolus syncing?"
           }
         },
@@ -19301,7 +20435,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "重新启用栓剂同步？"
+            "value" : "重新启用大剂量同步？"
           }
         }
       }
@@ -19315,10 +20449,16 @@
             "value" : "تم استلام سلاسل سداسي عشري غير صالحة. حاول مرة أخرى"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Přijaté neplatné hexadecimální řetězce. Zkuste to znovu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ugyldige hex-strenge modtaget. Forsøg igen"
+            "value" : "Modtog ugyldige hex-strenge. Prøv igen"
           }
         },
         "de" : {
@@ -19347,7 +20487,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Received invalid hex strings. Try again"
           }
         },
@@ -19361,6 +20501,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ricevute stringhe esadecimali non valide. Riprovare"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mottok ugyldige hex-strenger. Prøv igjen"
           }
         },
         "nb-NO" : {
@@ -19452,10 +20598,16 @@
             "value" : "تم استلام أطوال الرمز السري غير صالحة. حاول مرة أخرى"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Přijaté neplatné délky pincode. Zkuste to znovu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ugyldige PIN-kodelængder modtaget. Forsøg igen"
+            "value" : "Modtog ugyldige pinkodelængder. Prøv igen"
           }
         },
         "de" : {
@@ -19484,7 +20636,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Received invalid pincode lengths. Try again"
           }
         },
@@ -19498,6 +20650,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ricevuto pincode di lunghezza non valida. Riprovare"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mottatt ugyldige pinkodelengder. Prøv igjen"
           }
         },
         "nb-NO" : {
@@ -19637,6 +20795,12 @@
             "value" : "Reconnect to pump"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koble til pumpen igjen"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19727,10 +20891,16 @@
             "value" : "إعادة توصيل المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Znovu připojte čerpadlo tp"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gentilslut tp-pumpe"
+            "value" : "Tilslut tp-pumpen igen"
           }
         },
         "de" : {
@@ -19765,7 +20935,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect tp pump"
           }
         },
@@ -19779,6 +20949,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ricollegare la pompa tp"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koble til tp-pumpen igjen"
           }
         },
         "nb-NO" : {
@@ -19870,10 +21046,16 @@
             "value" : "إعادة الاتصال..."
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Obnovení spojení..."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Genforbinder..."
+            "value" : "At genskabe forbindelsen..."
           }
         },
         "de" : {
@@ -19902,7 +21084,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnecting..."
           }
         },
@@ -19916,6 +21098,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riconnettersi..."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kobler til igjen..."
           }
         },
         "nb-NO" : {
@@ -20007,6 +21195,12 @@
             "value" : "كمية إعادة التعبئة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Množství náplně"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20039,7 +21233,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Refill amount"
           }
         },
@@ -20053,6 +21247,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quantità di ricarica"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Påfyllingsmengde"
           }
         },
         "nb-NO" : {
@@ -20144,6 +21344,12 @@
             "value" : "مستوى الأنسولين المتبقي"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zbývající hladina inzulínu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20176,7 +21382,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Remaining insulin level"
           }
         },
@@ -20190,6 +21396,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Livello di insulina rimanente"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gjenværende insulinnivå"
           }
         },
         "nb-NO" : {
@@ -20281,10 +21493,16 @@
             "value" : "إزالة المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Odstranění čerpadla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fjern pumpe"
+            "value" : "Fjern pumpen"
           }
         },
         "de" : {
@@ -20301,8 +21519,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove Pump"
+            "state" : "translated",
+            "value" : "Poista pumppu"
           }
         },
         "fr" : {
@@ -20313,7 +21531,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Remove Pump"
           }
         },
@@ -20329,6 +21547,12 @@
             "value" : "Rimuovi microinfusore"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fjern pumpen"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20338,7 +21562,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Verwijder Pod"
+            "value" : "Pomp verwijderen"
           }
         },
         "pl" : {
@@ -20403,8 +21627,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove Pump"
+            "state" : "translated",
+            "value" : "卸下泵"
           }
         }
       }
@@ -20418,10 +21642,16 @@
             "value" : "عمر الخزان"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stáří nádrže"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reservoiralder"
+            "value" : "Reservoirets alder"
           }
         },
         "de" : {
@@ -20450,7 +21680,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reservoir age"
           }
         },
@@ -20464,6 +21694,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Età del serbatoio"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reservoarets alder"
           }
         },
         "nb-NO" : {
@@ -20558,7 +21794,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reservoirmængde"
+            "value" : "Mængde i reservoiret"
           }
         },
         "de" : {
@@ -20587,7 +21823,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reservoir amount"
           }
         },
@@ -20601,6 +21837,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quantità del serbatoio"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reservoarmengde"
           }
         },
         "nb-NO" : {
@@ -20692,6 +21934,12 @@
             "value" : "الخزان والقنية"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zásobník a kanyla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20724,7 +21972,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reservoir and cannula"
           }
         },
@@ -20738,6 +21986,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Serbatoio e cannula"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reservoar og kanyle"
           }
         },
         "nb-NO" : {
@@ -20829,10 +22083,16 @@
             "value" : "الخزان فارغ. استبدله الآن!"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nádrž je prázdná. Okamžitě ji vyměňte!"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reservoiret er tomt. Udskift det nu!"
+            "value" : "Reservoiret er tomt. Udskift den nu!"
           }
         },
         "de" : {
@@ -20861,7 +22121,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reservoir is empty. Replace it now!"
           }
         },
@@ -20875,6 +22135,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il serbatoio è vuoto. Sostituirlo subito!"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reservoaret er tomt. Bytt det ut nå!"
           }
         },
         "nb-NO" : {
@@ -20966,10 +22232,16 @@
             "value" : "إعادة تعبئة الخزان/كانولا"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doplňování nádržky/kanystru"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reservoir-/kanylegenopfyldning"
+            "value" : "Genopfyldning af reservoir/kanyle"
           }
         },
         "de" : {
@@ -20998,7 +22270,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reservoir/cannula refill"
           }
         },
@@ -21012,6 +22284,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ricarica del serbatoio/cannula"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Påfylling av reservoar/kanyle"
           }
         },
         "nb-NO" : {
@@ -21099,20 +22377,26 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Resume"
+            "state" : "translated",
+            "value" : "السيرة الذاتية"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Životopis"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Genoptag"
+            "value" : "CV"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fortsetzen"
+            "value" : "Lebenslauf"
           }
         },
         "es" : {
@@ -21123,19 +22407,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Resume"
+            "state" : "translated",
+            "value" : "Yhteenveto"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reprendre"
+            "value" : "Curriculum vitae"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Resume"
           }
         },
@@ -21149,6 +22433,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riprendi"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gjenoppta"
           }
         },
         "nb-NO" : {
@@ -21165,8 +22455,8 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Resume"
+            "state" : "translated",
+            "value" : "Wznowiono"
           }
         },
         "pt" : {
@@ -21179,6 +22469,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Resume"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reluați"
           }
         },
         "ru" : {
@@ -21226,7 +22522,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "恢复"
+            "value" : "简历"
           }
         }
       }
@@ -21236,20 +22532,26 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Resume delivery"
+            "state" : "translated",
+            "value" : "استئناف التسليم"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dodání životopisu"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Fortsæt indgivelse"
+            "value" : "Levering af CV"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulinabgabe fortsetzen"
+            "value" : "Lieferung starten"
           }
         },
         "es" : {
@@ -21260,19 +22562,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Resume delivery"
+            "state" : "translated",
+            "value" : "Jatko-osan toimitus"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Reprendre l'administration"
+            "value" : "Remise de curriculum vitae"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Resume delivery"
           }
         },
@@ -21288,6 +22590,12 @@
             "value" : "Riprendi erogazione"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gjenoppta levering"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21297,7 +22605,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hervat toediening"
+            "value" : "Hervatten"
           }
         },
         "pl" : {
@@ -21362,8 +22670,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Resume delivery"
+            "state" : "translated",
+            "value" : "简历交付"
           }
         }
       }
@@ -21374,19 +22682,25 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "إحفظ"
+            "value" : "الحفظ"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uložit"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gem"
+            "value" : "Gemme"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Speichern"
+            "value" : "Speichern in Pumpe"
           }
         },
         "es" : {
@@ -21404,12 +22718,12 @@
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sauvegarder"
+            "value" : "Économiser"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Save"
           }
         },
@@ -21423,6 +22737,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Salva"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lagre"
           }
         },
         "nb-NO" : {
@@ -21500,7 +22820,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "保存​​"
+            "value" : "节省"
           }
         }
       }
@@ -21559,6 +22879,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Scan"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Søk"
           }
         },
         "nb-NO" : {
@@ -21647,19 +22973,25 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "يتم المسح"
+            "value" : "المسح الضوئي"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skenování"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Skanner"
+            "value" : "Scanning"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Scannt"
+            "value" : "Scannen"
           }
         },
         "es" : {
@@ -21670,19 +23002,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Scanning"
+            "state" : "translated",
+            "value" : "Skannaus"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Balayage"
+            "value" : "Numérisation"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scanning"
           }
         },
@@ -21698,6 +23030,12 @@
             "value" : "Lettura"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Søker"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21707,7 +23045,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Aan het scannen"
+            "value" : "Scannen"
           }
         },
         "pl" : {
@@ -21772,8 +23110,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Scanning"
+            "state" : "translated",
+            "value" : "扫描"
           }
         }
       }
@@ -21784,19 +23122,25 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الجرعة الأساسية المجدولة"
+            "value" : "القاعدية المجدولة"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Plánovaný bazální"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Planlagt Basal"
+            "value" : "Planlagt basal"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Geplante Basalrate"
+            "value" : "Geplant Basal"
           }
         },
         "es" : {
@@ -21807,19 +23151,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Scheduled Basal"
+            "state" : "translated",
+            "value" : "Aikataulun mukainen Basal"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basal programmé"
+            "value" : "Basale programmée"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scheduled Basal"
           }
         },
@@ -21835,6 +23179,12 @@
             "value" : "Basale programmata"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Planlagt basal"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21844,7 +23194,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Gepland basaal"
+            "value" : "Gepland Basaal"
           }
         },
         "pl" : {
@@ -21910,7 +23260,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "预设基础率"
+            "value" : "预定的基质"
           }
         }
       }
@@ -21924,10 +23274,16 @@
             "value" : "وظيفة التمرير"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funkce posouvání"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rullefunktion"
+            "value" : "Scroll-funktion"
           }
         },
         "de" : {
@@ -21956,7 +23312,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scroll function"
           }
         },
@@ -21970,6 +23326,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Funzione di scorrimento"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rulle funksjon"
           }
         },
         "nb-NO" : {
@@ -22061,16 +23423,22 @@
             "value" : "ثانية"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sec"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "sek"
+            "value" : "sek."
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "sek"
+            "value" : "sec"
           }
         },
         "es" : {
@@ -22081,19 +23449,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "sec"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "sec"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "sec"
           }
         },
@@ -22246,6 +23614,12 @@
             "value" : "Select insulin type"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Velg insulintype"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "new",
@@ -22320,8 +23694,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Select insulin type"
+            "state" : "translated",
+            "value" : "选择胰岛素类型"
           }
         }
       }
@@ -22334,6 +23708,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "اختر نوع الأنسولين"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vyberte typ inzulínu"
           }
         },
         "da" : {
@@ -22374,7 +23754,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin Type"
           }
         },
@@ -22388,6 +23768,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selezionare il tipo di insulina"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Velg insulintype"
           }
         },
         "nb-NO" : {
@@ -22479,10 +23865,16 @@
             "value" : "حدد نوع الأنسولين الذي ستستخدمه في هذه المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vyberte typ inzulínu, který budete v této pumpě používat."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vælg insulintypen, pumpen skal anvende"
+            "value" : "Vælg den type insulin, du vil bruge i denne pumpe"
           }
         },
         "de" : {
@@ -22511,7 +23903,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select the type of insulin that you will be using in this pump"
           }
         },
@@ -22525,6 +23917,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Selezionare il tipo di insulina da utilizzare in questo microinfusore"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Velg insulintypen du vil bruke i denne pumpen"
           }
         },
         "nb-NO" : {
@@ -22664,6 +24062,12 @@
             "value" : "Seleziona il tipo di insulina che utilizzerai in questo microinfusore."
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Velg insulintypen du vil bruke i denne pumpen."
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22738,8 +24142,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Select the type of insulin that you will be using in this pump."
+            "state" : "translated",
+            "value" : "选择您将在此泵中使用的胰岛素类型。"
           }
         }
       }
@@ -22753,10 +24157,16 @@
             "value" : "اختر المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vyberte si své čerpadlo"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vælg pumpemodel"
+            "value" : "Vælg din pumpe"
           }
         },
         "de" : {
@@ -22785,7 +24195,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select your pump"
           }
         },
@@ -22801,6 +24211,12 @@
             "value" : "Selezionare la pompa"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Velg din pumpe"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "new",
@@ -22810,7 +24226,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Selecteer je pomp"
+            "value" : "Selecteer uw pomp"
           }
         },
         "pl" : {
@@ -22890,6 +24306,12 @@
             "value" : "تعيين تذكير لقطع الاتصال"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nastavení připomenutí odpojení"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22922,7 +24344,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Set reminder for disconnect"
           }
         },
@@ -22936,6 +24358,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impostare un promemoria per la disconnessione"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Angi påminnelse for frakobling"
           }
         },
         "nb-NO" : {
@@ -23028,10 +24456,16 @@
             "value" : "اضبط ملف التعريف القاعدي الذي يجب أن تستخدمه المضخة. لاحظ أنه سيحل محل الملف الشخصي الموجود في المضخة بالملف الشخصي الموجود في %1$@"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nastavte bazální profil, který má čerpadlo používat. Všimněte si, že se přepíše profil, který je v čerpadle, profilem na %1$@."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indstil basalprofilen pumpen skal anvende. Bemærk, at pumpens interne profil overskrives med den fra %1$@"
+            "value" : "Indstil den basalprofil, som pumpen skal bruge. Bemærk, at det vil overskrive den profil, der er i pumpen, med den, der er i %1$@"
           }
         },
         "de" : {
@@ -23066,7 +24500,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Set the basal profile the pump should use. Note, that it will overwrite the profile that is in the pump, with the one in %1$@"
           }
         },
@@ -23080,6 +24514,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Imposta il profilo basale che il microinfusore deve utilizzare. Si noti che il profilo presente nel microinfusore verrà sovrascritto con quello presente in %1$@."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Angi basalprofilen pumpen skal bruke. Merk at den vil overskrive profilen som er i pumpen, med profilen i %1$@"
           }
         },
         "nb-NO" : {
@@ -23172,10 +24612,16 @@
             "value" : "ضبط درجة الحرارة الأساسية غير مدعوم في الوقت الحالي"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nastavení bazální teploty není v tuto chvíli podporováno."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Indstilling af basaltemperatur understøttes p.t. ikke"
+            "value" : "Indstilling af basaltemperatur understøttes ikke på nuværende tidspunkt"
           }
         },
         "de" : {
@@ -23210,7 +24656,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setting temp basal is not supported at this time"
           }
         },
@@ -23224,6 +24670,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "L'impostazione della temp basale non è attualmente supportata."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Innstilling av temp basal støttes ikke for øyeblikket"
           }
         },
         "nb-NO" : {
@@ -23315,6 +24767,12 @@
             "value" : "إعداد دانا-i"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nastavení Dana-i"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23347,7 +24805,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setting up Dana-i"
           }
         },
@@ -23452,6 +24910,12 @@
             "value" : "إعداد DanaRS v1"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nastavení systému DanaRS v1"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23484,7 +24948,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setting up DanaRS v1"
           }
         },
@@ -23589,6 +25053,12 @@
             "value" : "إعداد DanaRS v3"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nastavení systému DanaRS v3"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23621,7 +25091,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setting up DanaRS v3"
           }
         },
@@ -23735,7 +25205,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Setup vollständig"
+            "value" : "Einrichtung fertig"
           }
         },
         "es" : {
@@ -23848,8 +25318,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Setup Complete"
+            "state" : "translated",
+            "value" : "设置完成"
           }
         }
       }
@@ -23863,10 +25333,16 @@
             "value" : "مشاركة سجلات مضخة دانا"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sdílet protokoly čerpadla Dana"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Del Dana-pumpelogger"
+            "value" : "Del Danas pumpelogs"
           }
         },
         "de" : {
@@ -23895,7 +25371,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Share Dana pump logs"
           }
         },
@@ -23908,7 +25384,7 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Condividi i registri delle pompe Dana"
+            "value" : "Condividi i registri della pompa Dana"
           }
         },
         "nb-NO" : {
@@ -24000,6 +25476,12 @@
             "value" : "يجب عرض الوقت في 12 ساعة أو 24 ساعة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Má se čas zobrazovat ve 12h nebo 24h"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24032,7 +25514,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Should time be display in 12h or 24h"
           }
         },
@@ -24045,7 +25527,7 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'ora deve essere visualizzata in 12 o 24 ore"
+            "value" : "L'orario dovrebbe essere visualizzato in 12 o 24 ore?"
           }
         },
         "nb-NO" : {
@@ -24137,6 +25619,12 @@
             "value" : "فقدان الإشارة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ztráta signálu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24157,8 +25645,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Signal Loss"
+            "state" : "translated",
+            "value" : "Signaalin menetys"
           }
         },
         "fr" : {
@@ -24169,7 +25657,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Signal Loss"
           }
         },
@@ -24182,7 +25670,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Perdita Di Segnale"
+            "value" : "Perdita segnale"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Signal Tap"
           }
         },
         "nb-NO" : {
@@ -24199,8 +25693,8 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Signal Loss"
+            "state" : "translated",
+            "value" : "Utrata sygnału"
           }
         },
         "pt" : {
@@ -24213,6 +25707,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Signal Loss"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pierdere de semnal"
           }
         },
         "ru" : {
@@ -24259,8 +25759,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Signal Loss"
+            "state" : "translated",
+            "value" : "信号丢失"
           }
         }
       }
@@ -24272,6 +25772,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "الصوت"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zvuk"
           }
         },
         "da" : {
@@ -24306,7 +25812,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Sound"
           }
         },
@@ -24411,6 +25917,12 @@
             "value" : "الحالة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stav"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24443,7 +25955,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Status"
           }
         },
@@ -24457,6 +25969,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Stato"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ステータス"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Status"
           }
         },
         "nb-NO" : {
@@ -24473,7 +25997,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Status"
           }
         },
@@ -24487,6 +26011,18 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Estado"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Estado"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stare"
           }
         },
         "ru" : {
@@ -24552,7 +26088,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Trin 1: Spæd kanylen"
+            "value" : "Trin 1: Klargør kanylen"
           }
         },
         "de" : {
@@ -24587,7 +26123,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Step 1: Prime cannula"
           }
         },
@@ -24695,7 +26231,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Trin 1: Indstil reservoirniveau"
+            "value" : "Trin 1: Indstil reservoirets niveau"
           }
         },
         "de" : {
@@ -24724,7 +26260,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Step 1: Set reservoir level"
           }
         },
@@ -24832,7 +26368,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Trin 2: Indstil tubegenopfyldningsmængde"
+            "value" : "Trin 2: Indstil mængden af tube-refill"
           }
         },
         "de" : {
@@ -24861,7 +26397,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Step 2: Set tube refill amount"
           }
         },
@@ -24973,8 +26509,8 @@
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Stop bolus"
+            "state" : "translated",
+            "value" : "Bolus abbrechen"
           }
         },
         "es" : {
@@ -25088,7 +26624,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "停止追加胰岛素注射"
+            "value" : "停止大剂量推注"
           }
         }
       }
@@ -25100,6 +26636,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "وقف درجة الحرارة القاعدية"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zastavení bazální teploty"
           }
         },
         "da" : {
@@ -25134,7 +26676,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop temp basal"
           }
         },
@@ -25235,20 +26777,26 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Suspend"
+            "state" : "translated",
+            "value" : "تعليق"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozastavit"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Suspender"
+            "value" : "Suspendere"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Unterbrechen"
+            "value" : "aussetzen."
           }
         },
         "es" : {
@@ -25259,8 +26807,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Suspend"
+            "state" : "translated",
+            "value" : "Keskeytä"
           }
         },
         "fr" : {
@@ -25271,7 +26819,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Suspend"
           }
         },
@@ -25287,6 +26835,12 @@
             "value" : "Sospendi"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suspendere"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25296,13 +26850,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Onderbreek"
+            "value" : "opschorten"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Suspend"
+            "state" : "translated",
+            "value" : "Wstrzymano"
           }
         },
         "pt" : {
@@ -25317,10 +26871,16 @@
             "value" : "Suspend"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suspendați"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Остановка"
+            "value" : "Приостановка"
           }
         },
         "sk" : {
@@ -25376,10 +26936,16 @@
             "value" : "تعليق التسليم"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pozastavení dodávky"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Suspendér levering"
+            "value" : "Suspender levering"
           }
         },
         "de" : {
@@ -25408,7 +26974,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Suspend delivery"
           }
         },
@@ -25513,10 +27079,16 @@
             "value" : "مزامنة بيانات المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synchronizace dat čerpadla"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Synk pumpedata"
+            "value" : "Synkroniser pumpedata"
           }
         },
         "de" : {
@@ -25545,7 +27117,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Sync pump data"
           }
         },
@@ -25657,8 +27229,8 @@
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "temp basal"
+            "state" : "translated",
+            "value" : "Temp. Basal"
           }
         },
         "es" : {
@@ -25782,20 +27354,26 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
+            "value" : "درجة الحرارة القاعدية"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Temp Basal"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Midlertidig Basal"
+            "value" : "Temp Basal"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Temporäre Basalrate"
+            "value" : "Temp. Basal"
           }
         },
         "es" : {
@@ -25806,19 +27384,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Temp Basal"
+            "state" : "translated",
+            "value" : "Lämpötila Peruslämpötila"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basal Temp."
+            "value" : "Temp Basal"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Temp Basal"
           }
         },
@@ -25909,7 +27487,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "临时基础率"
+            "value" : "基础温度"
           }
         }
       }
@@ -25923,10 +27501,16 @@
             "value" : "تدعم مضخات دانا سرعات توصيل مختلفة. يمكنك إعدادها هنا"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Čerpadla Dana podporují různé rychlosti dodávky. Nastavit je můžete zde"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dana-pumperne understøtter forskellige leveringshastigheder. Disse kan opsættes her"
+            "value" : "Dana-pumperne understøtter forskellige leveringshastigheder. Du kan sætte det op her"
           }
         },
         "de" : {
@@ -25955,7 +27539,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The Dana pumps support different delivery speeds. You can set it up here"
           }
         },
@@ -26060,10 +27644,16 @@
             "value" : "تدعم مضخات دانا سرعات توصيل مختلفة. يمكنك إعدادها هنا، ولكن أيضاً في قائمة الإعدادات"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Čerpadla Dana podporují různé rychlosti dodávky. Můžete je nastavit zde, ale také v nabídce nastavení."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dana-pumperne understøtter forskellige leveringshastigheder, hvilket kan indstilles her eller via indstillingsmenuen"
+            "value" : "Dana-pumperne understøtter forskellige leveringshastigheder. Du kan indstille det her, men også i indstillingsmenuen"
           }
         },
         "de" : {
@@ -26092,7 +27682,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The Dana pumps support different delivery speeds. You can set it up here, but also in the settings menu"
           }
         },
@@ -26197,10 +27787,16 @@
             "value" : "تم تعليق توصيل الأنسولين. فشل الإجراء"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Podávání inzulínu bylo pozastaveno. Akce se nezdařila"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulinleveringen er blevet suspenderet. Handling mislykkedes"
+            "value" : "Tilførslen af insulin er blevet suspenderet. Handling mislykkedes"
           }
         },
         "de" : {
@@ -26229,7 +27825,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The insulin delivery has been suspend. Action failed"
           }
         },
@@ -26334,6 +27930,12 @@
             "value" : "تم الوصول إلى الحد الأقصى للجرعة القصوى. يُرجى تجربة كمية أقل أو زيادة الحد الأقصى"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Je dosaženo maximálního limitu bolusu. Vyzkoušejte nižší množství nebo zvyšte limit"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26366,7 +27968,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The max bolus limit is reached. Please try a lower amount or increase the limit"
           }
         },
@@ -26457,7 +28059,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "已达到最大药量限制。请尝试更低的量或增加限制"
+            "value" : "已达到最大剂量上限。请尝试更低的大剂量或提高上限"
           }
         }
       }
@@ -26471,10 +28073,16 @@
             "value" : "تم الوصول إلى الحد الأقصى اليومي للأنسولين. يُرجى تجربة كمية أقل أو زيادة الحد الأقصى"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Je dosažen maximální denní limit inzulínu. Vyzkoušejte nižší množství nebo zvyšte limit"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Den maksimale daglige insulingrænse er nået. Prøv en lavere mængde, eller øg grænsen"
+            "value" : "Den maksimale daglige insulin-grænse er nået. Prøv en lavere mængde, eller øg grænsen."
           }
         },
         "de" : {
@@ -26503,7 +28111,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The max daily insulin limit is reached. Please try a lower amount or increase the limit"
           }
         },
@@ -26608,6 +28216,12 @@
             "value" : "اكتشفت المضخة وجود مشكلة في عمودها. يرجى إزالة الخزان وفحص كل شيء والمحاولة مرة أخرى"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Čerpadlo zjistilo problém s řetězem. Vyjměte nádržku, vše zkontrolujte a zkuste to znovu."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26640,7 +28254,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump has detected an issue with its chaft. Please remove the reservoir, check everything and try again"
           }
         },
@@ -26879,42 +28493,48 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "الوقت في مضختك مختلف عن الوقت الحالي. هل ترغب في تحديث الوقت في مضختك ليتوافق مع الوقت الحالي؟"
+            "value" : "الوقت على مضختك مختلف عن الوقت الحالي. هل تريد تحديث الوقت على مضختك إلى الوقت الحالي؟"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Čas na čerpadle se liší od aktuálního času. Chcete aktualizovat čas na čerpadle na aktuální čas?"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tiden på din pumpe er forskellig fra den aktuelle tid. Vil du opdatere tiden på din pumpe til det aktuelle tidspunkt?"
+            "value" : "Tiden på din pumpe er forskellig fra den aktuelle tid. Vil du opdatere tiden på din pumpe til den aktuelle tid?"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Die Zeit Ihrer Pumpe unterscheidet sich von der aktuellen Zeit. Möchten Sie die Pumpenzeit auf die aktuelle Zeit aktualisieren?"
+            "value" : "Die Zeit auf Ihrer Pumpe weicht von der aktuellen Zeit ab. Möchten Sie die Zeit auf Ihrer Pumpe auf die aktuelle Zeit aktualisieren?"
           }
         },
         "es" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La hora de la bomba es diferente de la hora actual. ¿Desea actualizar la hora de su bomba a la hora actual?"
+            "value" : "La hora de la bomba es diferente de la hora actual. Desea actualizar la hora de su bomba a la hora actual?"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
+            "state" : "translated",
+            "value" : "Pumppusi kellonaika poikkeaa nykyisestä kellonajasta. Haluatko päivittää pumppusi ajan nykyiseen aikaan?"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'heure de votre pompe est différente de l'heure actuelle. Voulez vous mettre à jour l'heure de votre pompe avec l'heure actuelle ?"
+            "value" : "L'heure de votre pompe est différente de l'heure actuelle. Voulez-vous mettre à jour l'heure de votre pompe pour qu'elle corresponde à l'heure actuelle ?"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
@@ -26927,7 +28547,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'ora sul microinfusore è diversa dall'ora corrente. Vuoi aggiornare l'ora del microinfusore all'ora corrente?"
+            "value" : "L'orario indicato sulla pompa è diverso dall'orario attuale. Vuoi aggiornare l'orario indicato sulla pompa con l'orario attuale?"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klokken på pumpen er forskjellig fra gjeldende tid. Vil du oppdatere tiden på pumpen til gjeldende tid?"
           }
         },
         "nb-NO" : {
@@ -26939,13 +28565,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "De pomptijd is anders dan de huidige tijd. Wil je de tijd van je pomp updaten naar de huidige tijd?"
+            "value" : "De tijd op je pomp is anders dan de huidige tijd. Wil je de tijd op je pomp bijwerken naar de huidige tijd?"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
+            "state" : "translated",
+            "value" : "Czas na pompie różni się od aktualnego. Czy chcesz zaktualizować czas na pompie?"
           }
         },
         "pt" : {
@@ -26960,10 +28586,16 @@
             "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ora de pe pompă este diferită de ora curentă. Puteți revizui ora pompei și să o sincronizați cu ora curentă în meniul setări."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Время на помпе отличается от текущего времени. Обновить время на помпе до текущего времени?"
+            "value" : "Время на вашей помпе отличается от текущего времени. Вы хотите обновить время на вашей помпе на текущее?"
           }
         },
         "sk" : {
@@ -26981,7 +28613,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pompanızdaki saat, mevcut saatten farklı. Pompanızdaki saati şu anki saate güncellemek ister misiniz?"
+            "value" : "Pompanızdaki saat geçerli saatten farklı. Pompanızdaki saati geçerli saate güncellemek istiyor musunuz?"
           }
         },
         "uk" : {
@@ -27004,8 +28636,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
+            "state" : "translated",
+            "value" : "泵上的时间与当前时间不同。您想将泵上的时间更新为当前时间吗？"
           }
         }
       }
@@ -27015,20 +28647,26 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
+            "state" : "translated",
+            "value" : "يختلف الوقت في مضختك عن الوقت الحالي. يتحكم وقت مضختك في إعدادات العلاج المجدول الخاص بك. قم بالتمرير لأسفل إلى صف وقت المضخة لمراجعة فرق الوقت وتهيئة المضخة الخاصة بك."
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Čas na čerpadle se liší od aktuálního času. Čas vaší pumpy řídí nastavení plánované terapie. Přejděte dolů na řádek Čas pumpy a zkontrolujte časový rozdíl a nastavte svou pumpu."
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tiden på din pumpe er forskellig fra den aktuelle tid. Din pumpes tid styrer dine planlagte behandlingsindstillinger. Gå til Pumpetid for at gennemgå tidsforskellen og konfigurere din pumpe."
+            "value" : "Tiden på din pumpe er forskellig fra den aktuelle tid. Din pumpes tid styrer dine planlagte behandlingsindstillinger. Rul ned til rækken Pumpetid for at se tidsforskellen og konfigurere din pumpe."
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Die Uhrzeit der Pumpe weicht von der aktuellen Uhrzeit ab. Die Zeit der Pumpe steuert die geplanten Therapieeinstellungen. Scrolle nach unten zur Zeile Pumpenzeit, um den Zeitunterschied zu überprüfen und die Pumpe zu konfigurieren."
+            "value" : "Die Uhrzeit auf Ihrer Pumpe unterscheidet sich von der aktuellen Uhrzeit. Die Zeit Ihrer Pumpe steuert Ihre geplanten Therapieeinstellungen. Blättern Sie nach unten zur Zeile Pumpenzeit, um den Zeitunterschied zu überprüfen und Ihre Pumpe zu konfigurieren."
           }
         },
         "es" : {
@@ -27039,20 +28677,20 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
+            "state" : "translated",
+            "value" : "Pumppusi kellonaika poikkeaa nykyisestä kellonajasta. Pumpun aika ohjaa ajastettuja hoitoasetuksia. Selaa alaspäin Pumpun aika -riville, jotta voit tarkistaa aikaeron ja määrittää pumpun asetukset."
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "L'heure de votre pompe est différente de l'heure actuelle. L'heure de votre pompe contrôle les paramètres de votre traitement. Faites défiler jusqu'à la ligne Heure de Pompe pour vérifier le décalage de l'heure et configurer votre pompe."
+            "value" : "L'heure de votre pompe est différente de l'heure actuelle. L'heure de votre pompe contrôle les paramètres de votre thérapie programmée. Faites défiler vers le bas jusqu'à la ligne Heure de la pompe pour consulter le décalage horaire et configurer votre pompe."
           }
         },
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "השעה במשאבה שלך שונה מהשעה הנוכחית. הגדרות הטיפול נקבעות לפי השעה במשאבה.  יש לבדוק את הפרשי הזמן ולעדכן את השעה במשאבה."
+            "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
           }
         },
         "hu" : {
@@ -27076,7 +28714,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "De tijd op je pomp is anders dan de huidige tijd. De tijd van je pomp bepaalt je geplande therapieinstellingen. Scroll omlaag naar de Pomptijd om het tijdsverschil te bekijken en de pomp te configureren."
+            "value" : "De tijd op je pomp verschilt van de huidige tijd. De tijd op je pomp bepaalt je geplande therapie-instellingen. Scroll naar beneden naar de rij Pomptijd om het tijdsverschil te bekijken en je pomp te configureren."
           }
         },
         "pl" : {
@@ -27141,8 +28779,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
+            "state" : "translated",
+            "value" : "泵上的时间与当前时间不同。泵上的时间控制着您的计划治疗设置。向下滚动到泵时间行，查看时差并配置您的泵。"
           }
         }
       }
@@ -27156,10 +28794,16 @@
             "value" : "لم يكن هناك أي تفاعل مع المضخة لفترة طويلة جداً. إما تعطيل هذه الوظيفة في المضخة أو التفاعل مع المضخة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Příliš dlouho nedocházelo k žádným interakcím s čerpadlem. Buď tuto funkci v čerpadle deaktivujte, nebo s čerpadlem interagujte"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Der har ikke været interaktioner med pumpen i for lang tid. Deaktivér enten denne funktion i pumpen, eller interagér med pumpen"
+            "value" : "Der har ikke været nogen interaktion med pumpen i for lang tid. Deaktiver enten denne funktion i pumpen, eller interager med pumpen."
           }
         },
         "de" : {
@@ -27188,7 +28832,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "There has not been any interactions with the pump for too long. Either disable this function in the pump or interact with the pump"
           }
         },
@@ -27279,7 +28923,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "太久没有与泵进行任何交互。要么禁用泵中的这一功能，要么与泵进行交互"
+            "value" : "长时间未与胰岛素泵进行交互。请在胰岛素泵中禁用此功能，或进行一次操作以恢复交互。"
           }
         }
       }
@@ -27296,7 +28940,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Denne genopfyldningsmetode er kun til situationer, hvor pumpen ingen mulighed har for at genopfylde reservoiret eller spæde kanylen"
+            "value" : "Denne metode til genopfyldning er kun beregnet til, når pumpen ikke kan give mulighed for at genopfylde reservoiret eller spæde kanylen."
           }
         },
         "de" : {
@@ -27325,7 +28969,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "This method of refilling is only intended for when the pump cannot provide a way to refill the reservoir or prime the cannula"
           }
         },
@@ -27427,19 +29071,25 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "تم اكتشاف تغيير في الوقت"
+            "value" : "تم اكتشاف تغير الوقت"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Zjištěná změna času"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tidsændring registreret"
+            "value" : "Tidsændring opdaget"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zeitänderung erkannt"
+            "value" : "Erkannte Zeitänderung"
           }
         },
         "es" : {
@@ -27450,19 +29100,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Time Change Detected"
+            "state" : "translated",
+            "value" : "Ajan muutos havaittu"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Changement de temps détecté"
+            "value" : "Changement d'heure détecté"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Time Change Detected"
           }
         },
@@ -27475,7 +29125,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Rilevato Cambio Di Tempo"
+            "value" : "Rilevato cambio di orario"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tidsendring oppdaget"
           }
         },
         "nb-NO" : {
@@ -27487,13 +29143,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Wijziging in tijd gedetecteerd"
+            "value" : "Tijdsverandering gedetecteerd"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Time Change Detected"
+            "state" : "translated",
+            "value" : "Wykryto zmianę czasu"
           }
         },
         "pt" : {
@@ -27506,6 +29162,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Time Change Detected"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "S-a detectat schimbarea orei"
           }
         },
         "ru" : {
@@ -27529,7 +29191,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Zaman Değişikliği Tespit Edildi"
+            "value" : "Zaman Değişikliği Algılandı"
           }
         },
         "uk" : {
@@ -27553,7 +29215,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "检测到时间变化"
+            "value" : "检测到时间变更"
           }
         }
       }
@@ -27567,10 +29229,16 @@
             "value" : "بلوتوث مودوس شاكيلين"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bluetooth modus schakelen"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Bluetooth-tilstand til/fra"
+            "value" : "Bluetooth modus schakelen"
           }
         },
         "de" : {
@@ -27599,7 +29267,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Toggle Bluetooth mode"
           }
         },
@@ -27704,10 +29372,16 @@
             "value" : "تبديل النغمة الصامتة؟"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Přepínání tichého tónu?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lydløs tone til/fra?"
+            "value" : "Toggle lydløs tone?"
           }
         },
         "de" : {
@@ -27736,7 +29410,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Toggle silent tone?"
           }
         },
@@ -27827,7 +29501,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "切换无声音调？"
+            "value" : "切换静音提示音？"
           }
         }
       }
@@ -27844,7 +29518,7 @@
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Tubegenopfyldningsmængde"
+            "value" : "Mængde til genopfyldning af rør"
           }
         },
         "de" : {
@@ -27873,7 +29547,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Tube refill amount"
           }
         },
@@ -27964,7 +29638,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "软管填充量"
+            "value" : "输注管补药剂量"
           }
         }
       }
@@ -27978,10 +29652,16 @@
             "value" : "نوع إعادة التعبئة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Typ náplně"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Genopfyldningstype"
+            "value" : "Type af refill"
           }
         },
         "de" : {
@@ -28010,7 +29690,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Type of refill"
           }
         },
@@ -28101,7 +29781,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "笔芯类型"
+            "value" : "补药类型"
           }
         }
       }
@@ -28115,16 +29795,22 @@
             "value" : "U"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "U"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "E"
+            "value" : "U"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : " IE"
+            "value" : "U"
           }
         },
         "es" : {
@@ -28135,7 +29821,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "U"
           }
         },
@@ -28147,7 +29833,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "U"
           }
         },
@@ -28163,6 +29849,12 @@
             "value" : "U"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28172,7 +29864,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "E"
+            "value" : "Eh"
           }
         },
         "pl" : {
@@ -28237,7 +29929,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "U"
           }
         }
@@ -28249,19 +29941,25 @@
         "ar" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "وحدة لكل ساعة"
+            "value" : "وحدة/ساعة"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "U/hod"
           }
         },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "E/t"
+            "value" : "U/time"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "IE/Std"
+            "value" : "U/Std."
           }
         },
         "es" : {
@@ -28272,8 +29970,8 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "U/hr"
+            "state" : "translated",
+            "value" : "U/h"
           }
         },
         "fr" : {
@@ -28284,7 +29982,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "U/hr"
           }
         },
@@ -28300,6 +29998,12 @@
             "value" : "U/ora"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "E/t"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28309,7 +30013,7 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "E/uur"
+            "value" : "Eh/u"
           }
         },
         "pl" : {
@@ -28375,7 +30079,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U/小时"
+            "value" : "U/hr"
           }
         }
       }
@@ -28385,8 +30089,14 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown"
+            "state" : "translated",
+            "value" : "غير معروف"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neznámý"
           }
         },
         "da" : {
@@ -28421,7 +30131,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Unknown"
           }
         },
@@ -28435,6 +30145,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sconosciuto"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ukjent"
           }
         },
         "nb-NO" : {
@@ -28526,6 +30242,12 @@
             "value" : "خطأ غير معروف"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Neznámá chyba"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28558,7 +30280,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Unknown error"
           }
         },
@@ -28572,6 +30294,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Errore sconosciuto"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ukjent feil"
           }
         },
         "nb-NO" : {
@@ -28663,6 +30391,12 @@
             "value" : "خيارات المستخدم"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Uživatelské možnosti"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28695,7 +30429,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "User options"
           }
         },
@@ -28709,6 +30443,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Opzioni utente"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Brukeralternativer"
           }
         },
         "nb-NO" : {
@@ -28800,16 +30540,22 @@
             "value" : "الاهتزاز"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vibrace"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vibration"
+            "value" : "Vibrationer"
           }
         },
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vibrieren"
+            "value" : "Vibration"
           }
         },
         "es" : {
@@ -28832,7 +30578,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Vibration"
           }
         },
@@ -28845,7 +30591,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Vibrazioni"
+            "value" : "Vibrazione"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vibrasjon"
           }
         },
         "nb-NO" : {
@@ -28945,8 +30697,8 @@
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "WARNING: Please don't use this until you've read the documentation"
+            "state" : "translated",
+            "value" : "ACHTUNG: Bitte nutze diese Funktion nicht bevor du die Dokumentation gelesen hast."
           }
         },
         "es" : {
@@ -28983,6 +30735,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ATTENZIONE: non utilizzare questo strumento prima di aver letto la documentazione"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ADVARSEL: Ikke bruk dette før du har lest dokumentasjonen"
           }
         },
         "nb-NO" : {
@@ -29106,7 +30864,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "WARNING: USE WITH CAUTION!"
           }
         },
@@ -29120,6 +30878,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ATTENZIONE: USARE CON CAUTELA!"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ADVARSEL: BRUK MED FORSIKTIGHET!"
           }
         },
         "nb-NO" : {
@@ -29211,10 +30975,16 @@
             "value" : "ما هذا؟"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Co je to?"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Hvad er dette?"
+            "value" : "Hvad er det her for noget?"
           }
         },
         "de" : {
@@ -29243,7 +31013,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "What is this?"
           }
         },
@@ -29256,7 +31026,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Che cos'è questo?"
+            "value" : "Cos'è questo?"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hva er dette?"
           }
         },
         "nb-NO" : {
@@ -29379,8 +31155,8 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes"
+            "state" : "translated",
+            "value" : "כן"
           }
         },
         "hu" : {
@@ -29392,7 +31168,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sì"
+            "value" : "SÌ"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja"
           }
         },
         "nb-NO" : {
@@ -29409,8 +31191,8 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes"
+            "state" : "translated",
+            "value" : "Tak"
           }
         },
         "pt" : {
@@ -29423,6 +31205,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Yes"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da"
           }
         },
         "ru" : {
@@ -29445,8 +31233,8 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes"
+            "state" : "translated",
+            "value" : "Evet"
           }
         },
         "uk" : {
@@ -29469,8 +31257,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes"
+            "state" : "translated",
+            "value" : "是"
           }
         }
       }
@@ -29482,6 +31270,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "نعم، 1 ساعة"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ano, 1 hodina"
           }
         },
         "da" : {
@@ -29516,7 +31310,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, 1 hour"
           }
         },
@@ -29530,6 +31324,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sì, 1 ora"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja, 1 time"
           }
         },
         "nb-NO" : {
@@ -29621,6 +31421,12 @@
             "value" : "نعم، 5 دقائق"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ano, 5 minut"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29653,7 +31459,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, 5 minutes"
           }
         },
@@ -29667,6 +31473,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sì, 5 minuti"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja, 5 minutter"
           }
         },
         "nb-NO" : {
@@ -29758,6 +31570,12 @@
             "value" : "نعم، 15 دقيقة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ano, 15 minut"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29790,7 +31608,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, 15 minutes"
           }
         },
@@ -29804,6 +31622,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sì, 15 minuti"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja, 15 minutter"
           }
         },
         "nb-NO" : {
@@ -29895,6 +31719,12 @@
             "value" : "نعم، 30 دقيقة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ano, 30 minut"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29927,7 +31757,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, 30 minutes"
           }
         },
@@ -29941,6 +31771,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sì, 30 minuti"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja, 30 minutter"
           }
         },
         "nb-NO" : {
@@ -30032,10 +31868,16 @@
             "value" : "نعم، تعطيل مزامنة البلعة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ano, vypněte synchronizaci bolusu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, deaktivér bolus-synkning"
+            "value" : "Ja, deaktiver bolus-synkronisering"
           }
         },
         "de" : {
@@ -30064,7 +31906,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, disable bolus syncing"
           }
         },
@@ -30077,7 +31919,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sì, disabilitare la sincronizzazione del bolo"
+            "value" : "Sì, disattiva la sincronizzazione del bolo"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja, deaktiver bolussynkronisering"
           }
         },
         "nb-NO" : {
@@ -30155,7 +32003,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "是，禁用栓剂同步"
+            "value" : "是的，禁用大剂量同步。"
           }
         }
       }
@@ -30169,10 +32017,16 @@
             "value" : "نعم، تعطيل النغمات الصامتة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ano, Zakázat tiché tóny"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, deaktivér lydløse toner"
+            "value" : "Ja, deaktiver lydløse toner"
           }
         },
         "de" : {
@@ -30201,7 +32055,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, Disable silent tones"
           }
         },
@@ -30215,6 +32069,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sì, disattiva i toni silenziosi"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja, Deaktiver lydløse toner"
           }
         },
         "nb-NO" : {
@@ -30306,10 +32166,16 @@
             "value" : "نعم، تمكين النغمات الصامتة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ano, Povolit tiché tóny"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, aktivér lydløse toner"
+            "value" : "Ja, aktiver lydløse toner"
           }
         },
         "de" : {
@@ -30338,7 +32204,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, Enable silent tones"
           }
         },
@@ -30351,7 +32217,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sì, abilita i toni silenziosi"
+            "value" : "Sì, attiva i toni silenziosi"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja, aktiver lydløse toner"
           }
         },
         "nb-NO" : {
@@ -30443,10 +32315,16 @@
             "value" : "نعم، أعد تمكين مزامنة البلعة"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ano, znovu povolte synchronizaci bolusu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, genaktivér bolus-synkning"
+            "value" : "Ja, genaktiver bolus-synkronisering"
           }
         },
         "de" : {
@@ -30475,7 +32353,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, re-enable bolus syncing"
           }
         },
@@ -30488,7 +32366,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sì, riattivare la sincronizzazione del bolo"
+            "value" : "Sì, riattiva la sincronizzazione del bolo"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja, aktiver bolussynkronisering på nytt"
           }
         },
         "nb-NO" : {
@@ -30566,7 +32450,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "是，重新启用药量同步"
+            "value" : "是的，重新启用大剂量同步"
           }
         }
       }
@@ -30578,6 +32462,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "نعم، قم بالتبديل إلى الوضع المستمر"
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ano, přepnutí na nepřetržitý režim"
           }
         },
         "da" : {
@@ -30612,7 +32502,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, Switch to continuous mode"
           }
         },
@@ -30626,6 +32516,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sì, passa alla modalità continua"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja, bytt til kontinuerlig modus"
           }
         },
         "nb-NO" : {
@@ -30717,6 +32613,12 @@
             "value" : "نعم، قم بالتبديل إلى الوضع التفاعلي"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ano, přepnutí do interaktivního režimu"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30749,7 +32651,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, Switch to interactive mode"
           }
         },
@@ -30763,6 +32665,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sì, passa alla modalità interattiva"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja, bytt til interaktiv modus"
           }
         },
         "nb-NO" : {
@@ -30854,6 +32762,12 @@
             "value" : "نعم، المزامنة مع الوقت الحالي"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ano, synchronizace s aktuálním časem"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30863,7 +32777,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, mit aktueller Zeit synchronisieren"
+            "value" : "Ja, Synchronisierung mit der aktuellen Zeit"
           }
         },
         "es" : {
@@ -30874,19 +32788,19 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, Sync to Current Time"
+            "state" : "translated",
+            "value" : "Kyllä, synkronointi nykyiseen aikaan"
           }
         },
         "fr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Oui, synchroniser avec l'heure actuelle"
+            "value" : "Oui, synchronisation avec l'heure actuelle"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, Sync to Current Time"
           }
         },
@@ -30899,7 +32813,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Sì, sincronizza con l'ora corrente"
+            "value" : "Sì, sincronizza con l'orario corrente"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ja, Synkroniser til gjeldende tid"
           }
         },
         "nb-NO" : {
@@ -30911,13 +32831,13 @@
         "nl" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, zet naar huidige tijd"
+            "value" : "Ja, synchroniseren met huidige tijd"
           }
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, Sync to Current Time"
+            "state" : "translated",
+            "value" : "Tak, zsynchronizuj z bieżącym czasem"
           }
         },
         "pt" : {
@@ -30930,6 +32850,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Yes, Sync to Current Time"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da, sincronizați cu ora curentă"
           }
         },
         "ru" : {
@@ -30953,7 +32879,7 @@
         "tr" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Evet güncelle"
+            "value" : "Evet, Geçerli Saatle Senkronize Et"
           }
         },
         "uk" : {
@@ -30976,8 +32902,8 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, Sync to Current Time"
+            "state" : "translated",
+            "value" : "是，与当前时间同步"
           }
         }
       }
@@ -30989,6 +32915,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "أنت "
+          }
+        },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vaše "
           }
         },
         "da" : {
@@ -31023,7 +32955,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your "
           }
         },
@@ -31037,6 +32969,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il tuo "
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Din"
           }
         },
         "nb-NO" : {
@@ -31128,10 +33066,16 @@
             "value" : "لقد تم الوصول إلى الحد الأساسي اليومي. يرجى الاتصال بموزع دانا الخاص بك لزيادة الحد المسموح به"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Váš denní bazální limit byl dosažen. Pro zvýšení limitu se obraťte na svého distributora Dana."
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Den daglige basalgrænse er nået. Kontakt Dana-distributøren for at øge grænsen"
+            "value" : "Din daglige basalgrænse er nået. Kontakt din Dana-distributør for at øge grænsen."
           }
         },
         "de" : {
@@ -31160,7 +33104,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your daily basal limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
@@ -31173,7 +33117,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Il limite giornaliero di basale è stato raggiunto. Contattare il distributore Dana per aumentare il limite."
+            "value" : "Il tuo limite giornaliero di basale è stato raggiunto. Contatta il tuo fornitore Dana per aumentare il limite."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Din daglige basalgrense er nådd. Ta kontakt med Dana-distributøren din for å øke grensen"
           }
         },
         "nb-NO" : {
@@ -31265,10 +33215,16 @@
             "value" : "تم الوصول إلى الحد اليومي للأنسولين. يرجى الاتصال بموزع دانا الخاص بك لزيادة الحد المسموح به"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Váš denní inzulínový limit byl dosažen. Pro zvýšení limitu se obraťte na svého distributora Dana"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Den daglige insulin-grænse er nået. Kontakt Dana-distributøren for at øge grænsen"
+            "value" : "Din daglige insulin-grænse er nået. Kontakt venligst din Dana-distributør for at øge grænsen."
           }
         },
         "de" : {
@@ -31297,7 +33253,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your daily insulin limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
@@ -31310,7 +33266,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Il limite giornaliero di insulina è stato raggiunto. Contattare il distributore Dana per aumentare il limite."
+            "value" : "Il tuo limite giornaliero d'insulina è stato raggiunto. Contatta il tuo fornitore Dana per aumentare il limite."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Din daglige insulingrense er nådd. Kontakt Dana-distributøren din for å øke grensen"
           }
         },
         "nb-NO" : {
@@ -31428,8 +33390,8 @@
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your pump is disconnected longer than 5 minutes!"
+            "state" : "translated",
+            "value" : "Votre pompe est déconnectée depuis plus de 5 minutes !"
           }
         },
         "he" : {
@@ -31448,6 +33410,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il tuo microinfusore è disconnesso da più di 5 minuti!"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpen din har vært frakoblet i mer enn 5 minutter!"
           }
         },
         "nb-NO" : {
@@ -31539,6 +33507,12 @@
             "value" : "لا تزال المضخة مفصولة بعد الفترة المحددة!"
           }
         },
+        "cs" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vaše čerpadlo je po uplynutí nastavené doby stále odpojeno!"
+          }
+        },
         "da" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31571,7 +33545,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your pump is still disconnected after the set period!"
           }
         },
@@ -31584,7 +33558,13 @@
         "it" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "La pompa è ancora scollegata dopo il periodo impostato!"
+            "value" : "Il tuo microinfusore è ancora disconnesso dopo il periodo di configurazione!"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpen din er fortsatt frakoblet etter den angitte perioden!"
           }
         },
         "nb-NO" : {

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -136,12 +136,6 @@
             "value" : " đã sẵn sàng để sử dụng!"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : " is ready to be used!"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -277,12 +271,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : ". Vui lòng vào cài đặt Bluetooth, quên thiết bị này rồi thử lại"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
         "zh-Hans" : {
@@ -427,12 +415,6 @@
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@%2$@ / %3$@%4$@"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "new",
@@ -567,12 +549,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "%@U"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "%@U"
           }
         },
@@ -711,12 +687,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "%1$@ units vẫn đang còn lúc %2$@"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ units remaining at %2$@"
           }
         },
         "zh-Hans" : {
@@ -861,12 +831,6 @@
             "value" : "%1$u %2$@"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$u %2$@"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "new",
@@ -1001,12 +965,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "12 sec/E"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "12 sec/E"
           }
         },
@@ -1160,12 +1118,6 @@
             "value" : "12 sec/U"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "12 sec/U"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1309,12 +1261,6 @@
             "value" : "Ký hiệu 12h"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "12h notation"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1455,12 +1401,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "24h display"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "24h display"
           }
         },
@@ -1607,12 +1547,6 @@
             "value" : "Ký hiệu 24h"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "24h notation"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -1747,12 +1681,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "30 sec/E"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "30 sec/E"
           }
         },
@@ -1906,12 +1834,6 @@
             "value" : "30 sec/U"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "30 sec/U"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2046,12 +1968,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "60 sec/E"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "60 sec/E"
           }
         },
@@ -2205,12 +2121,6 @@
             "value" : "60 sec/U"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "60 sec/U"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2352,12 +2262,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lời nhắc kiểm tra lượng đường trong máu đã được thiết lập trong máy bơm của bạn và được kích hoạt. Vui lòng tháo nó ra hoặc đưa mức đường huyết của bạn vào máy bơm"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "A blood glucose check reminder has been setup in your pump and is triggered. Please remove it or give your glucose level to the pump"
           }
         },
         "zh-Hans" : {
@@ -2503,12 +2407,6 @@
             "value" : "Thời gian chờ bolus đang hoạt động. Chu kỳ vòng lặp không thể hoàn tất cho đến khi thời gian chờ không hoạt động"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2650,12 +2548,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hành động đã bị hủy, vì máy bơm đang bận"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Action has been canceled, because the pump is busy"
           }
         },
         "zh-Hans" : {
@@ -2807,12 +2699,6 @@
             "value" : "Sau khi thiết lập loại insulin và tốc độ bolus, bạn sẽ thấy màn hình với tất cả các máy bơm Dana được tìm thấy. Chọn máy bơm bạn muốn liên kết với %1$@."
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "After setting up the insulin type and bolus speed, you will see a screen with all found Dana pumps. Select the pump you want to link with %1$@."
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -2954,12 +2840,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Báo động tiếp beeps"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Alarm beeps"
           }
         },
         "zh-Hans" : {
@@ -3105,12 +2985,6 @@
             "value" : "Đã xảy ra lỗi không xác định trong quá trình xử lý cảnh báo từ máy bơm. Vui lòng báo cáo lỗi này"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "An unknown error has occurred during processing the alert from the pump. Please report this"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3247,12 +3121,6 @@
             "value" : "Bạn có chắc chắn muốn bolus 5E không?"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to bolus 5E?"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3387,12 +3255,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bạn có chắc chắn muốn đặt basal tạm thời 200% trong 1 giờ không?"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
         "zh-Hans" : {
@@ -3538,12 +3400,6 @@
             "value" : "Bạn có chắc chắn muốn ngừng sử dụng Dana-i không?"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Are you sure you want to stop using Dana-i/RS?"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3681,12 +3537,6 @@
             "value" : "Đèn nền theo thời gian"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Backlight on time"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -3821,12 +3671,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Basal"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Basal"
           }
         },
@@ -3967,12 +3811,6 @@
             "value" : "Basal Compare"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Basal Compare"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4108,12 +3946,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã đạt đến giới hạn liều cơ bản"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Basal limit reached"
           }
         },
         "zh-Hans" : {
@@ -4253,12 +4085,6 @@
             "value" : "Phác đồ liều nền"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Basal profile"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4387,12 +4213,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Battery age"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Battery age"
           }
         },
@@ -4525,12 +4345,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pin đã hết. Hãy thay ngay!"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery is empty. Replace it now!"
           }
         },
         "zh-Hans" : {
@@ -4670,12 +4484,6 @@
             "value" : "Mức pin"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Battery level"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4811,12 +4619,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trước khi bắt đầu quá trình ghép nối, bạn nên kiểm tra và nếu cần hãy cập nhật mật khẩu máy bơm. Bạn có thể thực hiện việc này bằng cách vào pump settings -> user settings -> password. Mật khẩu mặc định là 1234, nếu đây là mật khẩu của bạn, vui lòng cân nhắc thay đổi mật khẩu"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Before starting with the pairing process, it is recommended to check, and if needed update, the pump password. You can do this by going to the pump settings -> user settings -> password. The default password is 1234, if this is your password, please consider changing it"
           }
         },
         "zh-Hans" : {
@@ -4956,12 +4758,6 @@
             "value" : "Kiểm tra đường huyết"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Blood glucose Measure"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5099,12 +4895,6 @@
             "value" : "Liều bolus"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Bolus Value"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5240,12 +5030,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cả hai"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Both"
           }
         },
         "zh-Hans" : {
@@ -5415,12 +5199,6 @@
             "value" : "Hủy bỏ"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Cancel"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5555,12 +5333,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Cannula age"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Cannula age"
           }
         },
@@ -5699,12 +5471,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chỉ Cannula"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Cannula only"
           }
         },
         "zh-Hans" : {
@@ -5851,12 +5617,6 @@
             "value" : "Nạp Cannula"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Cannula refill"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -5991,12 +5751,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Check chaft"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Check chaft"
           }
         },
@@ -6137,12 +5891,6 @@
             "value" : "Kiểm tra máy bơm và thử lại"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Check the pump and try again"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6278,12 +6026,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hãy Kiểm tra bình chứa và dây truyền và thử lại"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Check the reservoir and infus and try again"
           }
         },
         "zh-Hans" : {
@@ -6423,12 +6165,6 @@
             "value" : "Đã kiểm tra tại"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Checked at"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6564,12 +6300,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kiểm tra tổng không thành công. Hãy thử lại"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Checksum failed. Try again"
           }
         },
         "zh-Hans" : {
@@ -6709,12 +6439,6 @@
             "value" : "Cấu hình"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Configuration"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6843,12 +6567,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kết nối"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Connect"
           }
         },
         "zh-Hans" : {
@@ -6986,12 +6704,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã kết nối"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Connected"
           }
         },
         "zh-Hans" : {
@@ -7137,12 +6849,6 @@
             "value" : "Đang kết nối"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Connecting"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7284,12 +6990,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tiếp tục"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Continue"
           }
         },
         "zh-Hans" : {
@@ -7435,12 +7135,6 @@
             "value" : "Đạt giới hạn hàng ngày"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Daily limit reached"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7581,12 +7275,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dana-i"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Dana-i"
           }
         },
@@ -7733,12 +7421,6 @@
             "value" : "Thiết lập Dana-i/RS"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dana-i/RS Setup"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -7880,12 +7562,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã tìm thấy Dana-RS v3!"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Dana-RS v3 found!"
           }
         },
         "zh-Hans" : {
@@ -8031,12 +7707,6 @@
             "value" : "DanaRS-v1"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DanaRS-v1"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8177,12 +7847,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "DanaRS-v3"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "DanaRS-v3"
           }
         },
@@ -8336,12 +8000,6 @@
             "value" : "day(s)"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "day(s)"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8478,12 +8136,6 @@
             "value" : "GỠ LỖI: Thao tác bolus"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DEBUG: Bolus action"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8618,12 +8270,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "GỠ LỖI: Thao tác basal tạm thời"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "DEBUG: Temp basal action"
           }
         },
         "zh-Hans" : {
@@ -8769,12 +8415,6 @@
             "value" : "Xóa bơm"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Delete pump"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8916,12 +8556,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xóa bơm"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Delete Pump"
           }
         },
         "zh-Hans" : {
@@ -9067,12 +8701,6 @@
             "value" : "Delivery speed"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Delivery speed"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9207,12 +8835,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã tìm thấy thiết bị!"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Device found!"
           }
         },
         "zh-Hans" : {
@@ -9365,12 +8987,6 @@
             "value" : "Tắt đồng bộ bolus?"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Disable bolus syncing?"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9505,12 +9121,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ngắt kết nối"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Disconnect"
           }
         },
         "zh-Hans" : {
@@ -9656,12 +9266,6 @@
             "value" : "Ngắt kết nối từ máy bơm"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Disconnect from pump"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -9803,12 +9407,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã ngắt kết nối"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Disconnected"
           }
         },
         "zh-Hans" : {
@@ -9954,12 +9552,6 @@
             "value" : "Đang ngắt kết nối..."
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Disconnecting..."
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10094,12 +9686,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thực hiện bolus"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Do bolus"
           }
         },
         "zh-Hans" : {
@@ -10245,12 +9831,6 @@
             "value" : "Bạn có muốn nhận thông báo khi máy bơm không được ngắt kết nối trong một khoảng thời gian cụ thể không?"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Do you wish to receive a notification when the pump is longer disconnected for a specific time?"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10385,12 +9965,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Xong"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Done"
           }
         },
         "zh-Hans" : {
@@ -10536,12 +10110,6 @@
             "value" : "Trong quá trình ghép nối, Dana-i của bạn sẽ hiển thị lời nhắc ghép nối trong khi iPhone của bạn sẽ hiển thị lời nhắc nhập mã ghép nối. Trên máy bơm của bạn, hãy chọn OK và nhập mã gồm 6 chữ số vào màn hình trên iPhone của bạn. Sau đó, %1$@ đã sẵn sàng giao tiếp với Dana-i của bạn"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "During the pairing process, your Dana-i will show a pairing prompt while your iPhone will show a prompt for a pairing code. On you pump, select OK and type the 6-digit code in screen on your iPhone. After that, %1$@ is ready to communicate with your Dana-i"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10677,12 +10245,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trong quá trình ghép nối, DanaRS v1 của bạn sẽ hiển thị lời nhắc ghép nối trong khi iPhone của bạn sẽ hiển thị lời nhắc nhập mã ghép nối. Trên máy bơm của bạn, hãy chọn OK và nhập mã trên iPhone của bạn. Sau đó, %1$@ đã sẵn sàng giao tiếp với DanaRS v1 của bạn"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
         "zh-Hans" : {
@@ -10829,12 +10391,6 @@
             "value" : "Trong quá trình ghép đôi, DanaRS v1 của bạn sẽ hiển thị một thông báo ghép đôi, trong khi iPhone sẽ hiển thị thông báo nhập mã ghép đôi. Trên bơm, hãy chọn OK và nhập mã đó trên iPhone của bạn. Sau đó, Loop sẽ sẵn sàng giao tiếp với DanaRS v1"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10979,12 +10535,6 @@
             "value" : "Trong quá trình ghép đôi, DanaRS v3 của bạn sẽ hiển thị một thông báo ghép đôi, trong khi iPhone sẽ hiển thị thông báo nhập mã ghép đôi. Trên bơm, hãy chọn OK và nhập mã đó trên iPhone của bạn. Sau đó, Loop sẽ sẵn sàng giao tiếp với DanaRS v1"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11120,12 +10670,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trong quá trình ghép đôi, DanaRS v3 của bạn sẽ hiển thị lời nhắc ghép đôi, trong khi iPhone của bạn sẽ hiển thị lời nhắc yêu cầu nhập hai mã ghép đôi. Trên bơm, hãy chọn OK và nhập hai mã đó trên iPhone của bạn. Sau đó, %1$@ đã sẵn sàng để giao tiếp với DanaRS v3 của bạn"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
         "zh-Hans" : {
@@ -11278,12 +10822,6 @@
             "value" : "Trong quá trình ghép đôi, DanaRS v3 của bạn sẽ hiển thị một thông báo ghép đôi, trong khi iPhone sẽ hiển thị thông báo nhập hai mã ghép đôi. Trên bơm, hãy chọn OK và nhập hai mã đó trên iPhone của bạn. Sau đó, Loop sẽ sẵn sàng giao tiếp với DanaRS v3"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11419,12 +10957,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hết insulin"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Empty reservoir"
           }
         },
         "zh-Hans" : {
@@ -11564,12 +11096,6 @@
             "value" : "Lỗi khi kết nối với thiết bị"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Error while connecting to device"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11698,12 +11224,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lỗi khi bắt đầu quét thiết bị..."
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Error while starting scanning for devices..."
           }
         },
         "zh-Hans" : {
@@ -11849,12 +11369,6 @@
             "value" : "LỖI: Không ghép nối được thiết bị"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "ERROR: Failed to pair device"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -11990,12 +11504,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Không thể điều chỉnh liều basal"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to adjust basal"
           }
         },
         "zh-Hans" : {
@@ -12135,12 +11643,6 @@
             "value" : "Không điều chỉnh được thời gian bơm"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to adjust pump time"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12276,12 +11778,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Không thể điều chỉnh bởi hệ thống treo"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to adjust suspension"
           }
         },
         "zh-Hans" : {
@@ -12428,12 +11924,6 @@
             "value" : "Không thể điều chỉnh liều temp basal"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to adjust temp basal"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12569,12 +12059,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Không tạo được liều basal Dana"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to generate Dana basal program"
           }
         },
         "zh-Hans" : {
@@ -12721,12 +12205,6 @@
             "value" : "Không thể kết nối"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to make a connection"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12858,12 +12336,6 @@
             "value" : "Ghép đôi thất bại với "
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to pair to "
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -12992,12 +12464,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Failed to prime the cannula. Please try again later"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Failed to prime the cannula. Please try again later"
           }
         },
@@ -13132,12 +12598,6 @@
             "value" : "Failed to prime the cannula. Please try again later"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to prime the tube. Please try again later"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13267,12 +12727,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Không thể thiết lập reservoir. Đồng bộ lại dữ liệu bơm và vui lòng thử lại"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Failed to set reservoir amount. Re-sync pump data and try again please"
           }
         },
         "zh-Hans" : {
@@ -13412,12 +12866,6 @@
             "value" : "Điền mật khẩu"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Fill in password"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13553,12 +13001,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Hoàn thành"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Finish"
           }
         },
         "zh-Hans" : {
@@ -13698,12 +13140,6 @@
             "value" : "Phiên bản phần mềm"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Firmware version"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13841,12 +13277,6 @@
             "value" : "Đã tìm thấy Dana-i"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Found Dana-i/RS pumps"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13982,12 +13412,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mô hình phần cứng"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Hardware model"
           }
         },
         "zh-Hans" : {
@@ -14133,12 +13557,6 @@
             "value" : "Insulin\n Đã tạm ngưng"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin\nSuspended"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14274,12 +13692,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Khối lượng tiêm insulin"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Delivery"
           }
         },
         "zh-Hans" : {
@@ -14419,12 +13831,6 @@
             "value" : "Insulin còn lại"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Remaining"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14560,12 +13966,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã tạm dừng cấp liều Insulin"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Suspended"
           }
         },
         "zh-Hans" : {
@@ -14705,12 +14105,6 @@
             "value" : "Loại Insulin"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Insulin Type"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14848,12 +14242,6 @@
             "value" : "Lần đồng bộ gần đây nhất"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Last sync"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -14989,12 +14377,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Màn hình Lcd time"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Lcd on time"
           }
         },
         "zh-Hans" : {
@@ -15147,12 +14529,6 @@
             "value" : "đang tải"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "loading"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15303,12 +14679,6 @@
             "value" : "Loading"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Loading"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15450,12 +14820,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pin của bơm yếu"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Low pump battery"
           }
         },
         "zh-Hans" : {
@@ -15601,12 +14965,6 @@
             "value" : "Báo nhắc gần hết thuốc"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Low reservoir reminder"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -15748,12 +15106,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đồng bộ thời gian bơm thủ công"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Manually sync Pump time"
           }
         },
         "zh-Hans" : {
@@ -15899,12 +15251,6 @@
             "value" : "Không thấy kiểm tra đường huyết"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Missed Blood glucose check"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16048,12 +15394,6 @@
             "value" : "Nightly pump time sync"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Nightly pump time sync"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16188,12 +15528,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Không"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No"
           }
         },
         "zh-Hans" : {
@@ -16345,12 +15679,6 @@
             "value" : "Hết Insulin"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No Insulin"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16492,12 +15820,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Không, chỉ cần ngắt kết nối"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No, just disconnect"
           }
         },
         "zh-Hans" : {
@@ -16643,12 +15965,6 @@
             "value" : "Không, giữ nguyên như vậy"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No, Keep as is"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16792,12 +16108,6 @@
             "value" : "Không, Giữ nguyên"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "No, Keep Pump As Is"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16933,12 +16243,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "LƯU Ý: DanaRS v1 hiện chưa được hỗ trợ. Nếu bạn có sẵn một bơm DanaRS v1 để thử nghiệm, vui lòng liên hệ với Bastiaan Verhaar!"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
         "zh-Hans" : {
@@ -17084,12 +16388,6 @@
             "value" : "Lưu ý: Máy bơm Dana của bạn có một cài đặt đặc biệt cho phép bạn tắt tiếng bíp của máy bơm Dana. Để bật chức năng này, vui lòng liên hệ với nhà phân phối Dana của bạn"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Note: You Dana pump has a special setting which allows you to silence your Dana pump beeps. To enable this, please contact your Dana distributor"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17230,12 +16528,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Occlusion"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Occlusion"
           }
         },
@@ -17380,12 +16672,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tắt"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Off"
           }
         },
         "zh-Hans" : {
@@ -17549,12 +16835,6 @@
             "value" : "OK"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "OK"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -17683,12 +16963,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Oke"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Oke"
           }
         },
@@ -17827,12 +17101,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bật"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "On"
           }
         },
         "zh-Hans" : {
@@ -17979,12 +17247,6 @@
             "value" : "Chỉ hỗ trợ liều Bolus tự động"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Only Automatic Bolus is supported"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18120,12 +17382,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mật khẩu DanaRS v1"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Password DanaRS v1"
           }
         },
         "zh-Hans" : {
@@ -18265,12 +17521,6 @@
             "value" : "Pin 1"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pin 1"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18405,12 +17655,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pin 2"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Pin 2"
           }
         },
@@ -18558,12 +17802,6 @@
             "value" : "Yêu cầu mã Pin"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pincode required"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18708,12 +17946,6 @@
             "value" : "Vui lòng cân nhắc thay đổi liều lượng của bạn trong menu cài đặt"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Please consider changing your dosing strategy in the setting menu"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -18843,12 +18075,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lượng insulin mồi"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Prime amount"
           }
         },
         "zh-Hans" : {
@@ -18985,12 +18211,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pump battery 0%"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Pump battery 0%"
           }
         },
@@ -19138,12 +18358,6 @@
             "value" : "Pin của máy bơm đã hết. Hãy thay ngay!"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump battery is empty. Replace it now!"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19281,12 +18495,6 @@
             "value" : "Pin máy bơm cần được thay thế sớm"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump battery needs to be replaced soon"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19421,12 +18629,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Pump error"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Pump error"
           }
         },
@@ -19567,12 +18769,6 @@
             "value" : "Thông tin máy bơm"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump information"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19702,12 +18898,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bơm đã ngắt kết nối"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump is disconnected"
           }
         },
         "zh-Hans" : {
@@ -19847,12 +19037,6 @@
             "value" : "Máy bơm vẫn chưa được ngắt kết nối"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump is still disconnected"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -19988,12 +19172,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tên máy bơm"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump name"
           }
         },
         "zh-Hans" : {
@@ -20133,12 +19311,6 @@
             "value" : "Pump shutdown"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump shutdown"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20274,12 +19446,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thời gian của Bơm"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Pump time"
           }
         },
         "zh-Hans" : {
@@ -20426,12 +19592,6 @@
             "value" : "Bật lại tính năng đồng bộ bolus không?"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Re-enable bolus syncing?"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20573,12 +19733,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chuỗi hex không hợp lệ. Hãy thử lại"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Received invalid hex strings. Try again"
           }
         },
         "zh-Hans" : {
@@ -20724,12 +19878,6 @@
             "value" : "Độ dài mã pin không hợp lệ. Hãy thử lại"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Received invalid pincode lengths. Try again"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20865,12 +20013,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kết nối lại máy bơm"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconnect to pump"
           }
         },
         "zh-Hans" : {
@@ -21023,12 +20165,6 @@
             "value" : "Kết nối lại máy bơm"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconnect tp pump"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21170,12 +20306,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đang kết nối lại..."
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reconnecting..."
           }
         },
         "zh-Hans" : {
@@ -21321,12 +20451,6 @@
             "value" : "Số lượng nạp lại"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Refill amount"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21468,12 +20592,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mức insulin còn lại"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Remaining insulin level"
           }
         },
         "zh-Hans" : {
@@ -21619,12 +20737,6 @@
             "value" : "Thay bơm"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Remove Pump"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21768,12 +20880,6 @@
             "value" : "Reservoir age"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reservoir age"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21909,12 +21015,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lượng bình chứa"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reservoir amount"
           }
         },
         "zh-Hans" : {
@@ -22060,12 +21160,6 @@
             "value" : "Reservoir và cannula"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reservoir and cannula"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22209,12 +21303,6 @@
             "value" : "Bình chứa đã cạn. Hãy thay thế ngay!"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reservoir is empty. Replace it now!"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22356,12 +21444,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nạp lại Reservoir/cannula"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Reservoir/cannula refill"
           }
         },
         "zh-Hans" : {
@@ -22513,12 +21595,6 @@
             "value" : "Tiếp tục"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Resume"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22660,12 +21736,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tiếp tục lại việc tiêm insulin"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Resume delivery"
           }
         },
         "zh-Hans" : {
@@ -22811,12 +21881,6 @@
             "value" : "Lưu"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Save"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -22951,12 +22015,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quét"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Scan"
           }
         },
         "zh-Hans" : {
@@ -23102,12 +22160,6 @@
             "value" : "Đang quét"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Scanning"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23249,12 +22301,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã lên chương trình cho liều Basal"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Scheduled Basal"
           }
         },
         "zh-Hans" : {
@@ -23400,12 +22446,6 @@
             "value" : "Chức năng cuộn"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Scroll function"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23540,12 +22580,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "sec"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "sec"
           }
         },
@@ -23684,12 +22718,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chọn loại insulin"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select insulin type"
           }
         },
         "zh-Hans" : {
@@ -23842,12 +22870,6 @@
             "value" : "Chọn loại insulin"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select insulin Type"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23991,12 +23013,6 @@
             "value" : "Chọn loại insulin mà bạn sẽ sử dụng trong máy bơm này"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select the type of insulin that you will be using in this pump"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24132,12 +23148,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chọn loại insulin bạn sẽ sử dụng trong máy bơm này."
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select the type of insulin that you will be using in this pump."
           }
         },
         "zh-Hans" : {
@@ -24283,12 +23293,6 @@
             "value" : "Chọn máy bơm của bạn"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Select your pump"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24430,12 +23434,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đặt lời nhắc ngắt kết nối"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Set reminder for disconnect"
           }
         },
         "zh-Hans" : {
@@ -24588,12 +23586,6 @@
             "value" : "Đặt cấu hình cơ bản mà máy bơm nên sử dụng. Lưu ý rằng nó sẽ ghi đè lên cấu hình có trong máy bơm, với cấu hình trong %1$@"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Set the basal profile the pump should use. Note, that it will overwrite the profile that is in the pump, with the one in %1$@"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24744,12 +23736,6 @@
             "value" : "Cài đặt liều temp basal không được hỗ trợ tại thời điểm này"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Setting temp basal is not supported at this time"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -24885,12 +23871,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thiết lập Dana-i"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Setting up Dana-i"
           }
         },
         "zh-Hans" : {
@@ -25030,12 +24010,6 @@
             "value" : "Thiết lập DanaRS v1"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Setting up DanaRS v1"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25173,12 +24147,6 @@
             "value" : "Thiết lập DanaRS v3"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Setting up DanaRS v3"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25308,12 +24276,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Cài đặt hoàn thành"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Setup Complete"
           }
         },
         "zh-Hans" : {
@@ -25453,12 +24415,6 @@
             "value" : "Chia sẻ nhật ký bơm Dana"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Share Dana pump logs"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25594,12 +24550,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thời gian được hiển thị 12h hoặc 24h"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Should time be display in 12h or 24h"
           }
         },
         "zh-Hans" : {
@@ -25751,12 +24701,6 @@
             "value" : "Mất tín hiệu"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Signal Loss"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -25892,12 +24836,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Âm thanh"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sound"
           }
         },
         "zh-Hans" : {
@@ -26061,12 +24999,6 @@
             "value" : "Tình trạng"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Status"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26205,12 +25137,6 @@
             "value" : "Bước 1: Prime cannula"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step 1: Prime cannula"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26340,12 +25266,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bước 1: Đặt mức Reservoir"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step 1: Set reservoir level"
           }
         },
         "zh-Hans" : {
@@ -26479,12 +25399,6 @@
             "value" : "Bước 2: Đặt lượng ống nạp lại"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Step 2: Set tube refill amount"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -26613,12 +25527,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Dừng bolus"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Stop bolus"
           }
         },
         "zh-Hans" : {
@@ -26756,12 +25664,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tạm dừng liều temp basal"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Stop temp basal"
           }
         },
         "zh-Hans" : {
@@ -26913,12 +25815,6 @@
             "value" : "Đã tạm dừng"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Suspend"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27054,12 +25950,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tạm ngưng liều insulin"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Suspend delivery"
           }
         },
         "zh-Hans" : {
@@ -27199,12 +26089,6 @@
             "value" : "Đồng bộ dữ liệu bơm"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Sync pump data"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27333,12 +26217,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "basal tạm thời"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "temp basal"
           }
         },
         "zh-Hans" : {
@@ -27475,12 +26353,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Temp Basal"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Temp Basal"
           }
         },
@@ -27621,12 +26493,6 @@
             "value" : "Máy bơm Dana hỗ trợ nhiều tốc độ phân phối khác nhau. Bạn có thể thiết lập ở đây"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The Dana pumps support different delivery speeds. You can set it up here"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -27762,12 +26628,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Máy bơm Dana hỗ trợ nhiều tốc độ phân phối khác nhau. Bạn có thể thiết lập ở đây, nhưng cũng có thể trong menu cài đặt"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The Dana pumps support different delivery speeds. You can set it up here, but also in the settings menu"
           }
         },
         "zh-Hans" : {
@@ -27907,12 +26767,6 @@
             "value" : "Việc cung cấp insulin đã bị tạm dừng. Hành động không thành công"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The insulin delivery has been suspend. Action failed"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28048,12 +26902,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Đã đạt đến giới hạn bolus tối đa. Vui lòng thử lượng thấp hơn hoặc tăng giới hạn"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The max bolus limit is reached. Please try a lower amount or increase the limit"
           }
         },
         "zh-Hans" : {
@@ -28193,12 +27041,6 @@
             "value" : "Đã đạt đến giới hạn insulin tối đa hàng ngày. Vui lòng thử lượng thấp hơn hoặc tăng giới hạn"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The max daily insulin limit is reached. Please try a lower amount or increase the limit"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28336,12 +27178,6 @@
             "value" : "Máy bơm đã phát hiện ra sự cố với chaft của nó. Vui lòng tháo bình chứa, kiểm tra mọi thứ và thử lại"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The pump has detected an issue with its chaft. Please remove the reservoir, check everything and try again"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28471,12 +27307,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bơm sẽ nhắc bạn khi lượng insulin trong bơm đạt đến mức này"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
         "zh-Hans" : {
@@ -28628,12 +27458,6 @@
             "value" : "Thời gian trên máy bơm của bạn khác với thời gian hiện tại. Bạn có muốn cập nhật thời gian trên máy bơm của mình đến thời điểm hiện tại không?"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -28769,12 +27593,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Thời gian trên máy bơm của bạn khác với thời gian hiện tại. Thời gian của máy bơm sẽ kiểm soát cài đặt trị liệu theo lịch trình của bạn. Cuộn xuống đến Pump Time để xem lại chênh lệch thời gian và cấu hình bơm của bạn."
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
           }
         },
         "zh-Hans" : {
@@ -28914,12 +27732,6 @@
             "value" : "Đã không có bất kỳ tương tác nào với máy bơm trong thời gian quá dài. Hãy vô hiệu hóa chức năng này trong máy bơm hoặc tương tác với máy bơm"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "There has not been any interactions with the pump for too long. Either disable this function in the pump or interact with the pump"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29049,12 +27861,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Phương pháp nạp lại này chỉ dành cho trường hợp máy bơm không thể nạp lại bình chứa hoặc mồi ống thông"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "This method of refilling is only intended for when the pump cannot provide a way to refill the reservoir or prime the cannula"
           }
         },
         "zh-Hans" : {
@@ -29206,12 +28012,6 @@
             "value" : "Đã phát hiện thay đổi thời gian"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Time Change Detected"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29347,12 +28147,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Chuyển đổi chế độ Bluetooth"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Toggle Bluetooth mode"
           }
         },
         "zh-Hans" : {
@@ -29492,12 +28286,6 @@
             "value" : "Chuyển đổi chế độ im lặng không?"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Toggle silent tone?"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29627,12 +28415,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Lượng ống nạp lại"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Tube refill amount"
           }
         },
         "zh-Hans" : {
@@ -29770,12 +28552,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Kiểu nạp lại"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Type of refill"
           }
         },
         "zh-Hans" : {
@@ -29918,12 +28694,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "U"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "U"
           }
         },
@@ -30070,12 +28840,6 @@
             "value" : "U/hr"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "U/hr"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30217,12 +28981,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Không xác định"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown"
           }
         },
         "zh-Hans" : {
@@ -30368,12 +29126,6 @@
             "value" : "Lỗi không xác định"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Unknown error"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30514,12 +29266,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "User options"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "User options"
           }
         },
@@ -30666,12 +29412,6 @@
             "value" : "Chế độ rung"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Vibration"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30809,12 +29549,6 @@
             "value" : "CẢNH BÁO: Vui lòng không sử dụng tính năng này cho đến khi bạn đã đọc tài liệu hướng dẫn"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "WARNING: Please don't use this until you've read the documentation"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -30950,12 +29684,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "CẢNH BÁO: SỬ DỤNG THẬN TRỌNG!"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "WARNING: USE WITH CAUTION!"
           }
         },
         "zh-Hans" : {
@@ -31101,12 +29829,6 @@
             "value" : "Đây là gì?"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "What is this?"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31247,12 +29969,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Có"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes"
           }
         },
         "zh-Hans" : {
@@ -31398,12 +30114,6 @@
             "value" : "Có, 1 giờ"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, 1 hour"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31545,12 +30255,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Có, 5 phút"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, 5 minutes"
           }
         },
         "zh-Hans" : {
@@ -31696,12 +30400,6 @@
             "value" : "Có, 15 phút"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, 15 minutes"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31843,12 +30541,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Có, 30 phút"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, 30 minutes"
           }
         },
         "zh-Hans" : {
@@ -31994,12 +30686,6 @@
             "value" : "Có, tắt đồng bộ bolus"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, disable bolus syncing"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32141,12 +30827,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Có, Tắt âm báo im lặng"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, Disable silent tones"
           }
         },
         "zh-Hans" : {
@@ -32292,12 +30972,6 @@
             "value" : "Có, Bật âm báo im lặng"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, Enable silent tones"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32439,12 +31113,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Có, bật lại đồng bộ bolus"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, re-enable bolus syncing"
           }
         },
         "zh-Hans" : {
@@ -32590,12 +31258,6 @@
             "value" : "Có, chuyển sang chế độ liên tục"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, Switch to continuous mode"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -32737,12 +31399,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Có, chuyển sang chế độ tương tác"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, Switch to interactive mode"
           }
         },
         "zh-Hans" : {
@@ -32894,12 +31550,6 @@
             "value" : "Có, đồng bộ với thời gian hiện tại"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Yes, Sync to Current Time"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33040,12 +31690,6 @@
         "vi" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Your "
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
             "value" : "Your "
           }
         },
@@ -33192,12 +31836,6 @@
             "value" : "Đã đạt đến giới hạn bolus tối đa. Vui lòng thử lượng thấp hơn hoặc tăng giới hạn"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your daily basal limit has been reached. Please contact your Dana distributer to increase the limit"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33341,12 +31979,6 @@
             "value" : "Đã đạt giới hạn insulin hàng ngày của bạn. Vui lòng liên hệ với nhà phân phối Dana của bạn để tăng giới hạn"
           }
         },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your daily insulin limit has been reached. Please contact your Dana distributer to increase the limit"
-          }
-        },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
@@ -33482,12 +32114,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Bơm của bạn đã bị ngắt kết nối hơn 5 phút!"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
         "zh-Hans" : {
@@ -33631,12 +32257,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Máy bơm của bạn vẫn bị ngắt kết nối sau thời gian đã đặt!"
-          }
-        },
-        "yy-YY" : {
-          "stringUnit" : {
-            "state" : "new",
-            "value" : "Your pump is still disconnected after the set period!"
           }
         },
         "zh-Hans" : {

--- a/Localization/Localizable.xcstrings
+++ b/Localization/Localizable.xcstrings
@@ -49,12 +49,12 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : " is ready to be used!"
+            "value" : " מוכנה לשימוש!"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : " is ready to be used!"
           }
         },
@@ -98,6 +98,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : " is ready to be used!"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : " este gata de utilizare!"
           }
         },
         "ru" : {
@@ -149,55 +155,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
@@ -221,7 +227,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
@@ -237,9 +243,15 @@
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : ". Vă rugăm să accesați setările bluetooth, să uitați acest dispozitiv și să încercați din nou"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
@@ -257,13 +269,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : ". Please go to your bluetooth settings, forget this device, and try again"
           }
         },
@@ -285,19 +297,19 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
@@ -309,37 +321,37 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
@@ -363,7 +375,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
@@ -379,9 +391,15 @@
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@%2$@ / %3$@%4$@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
@@ -399,13 +417,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         },
@@ -417,7 +435,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@%2$@ / %3$@%4$@"
           }
         }
@@ -428,7 +446,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%@U"
           }
         },
@@ -464,13 +482,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%@U"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%@U"
           }
         },
@@ -516,6 +534,12 @@
             "value" : "%@U"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%@U"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -554,7 +578,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%@U"
           }
         }
@@ -565,7 +589,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@ units remaining at %2$@"
           }
         },
@@ -601,13 +625,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "%1$@ units remaining at %2$@"
+            "state" : "translated",
+            "value" : "%1$@ יחידות נותרו בשעה %2$@"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@ units remaining at %2$@"
           }
         },
@@ -653,6 +677,12 @@
             "value" : "%1$@ unidades restantes em %2$@"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$@ unități rămase la %2$@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -691,7 +721,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$@ units remaining at %2$@"
           }
         }
@@ -701,19 +731,19 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
@@ -725,37 +755,37 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
@@ -779,7 +809,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
@@ -795,9 +825,15 @@
             "value" : "%1$u %2$@"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "%1$u %2$@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
@@ -815,13 +851,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         },
@@ -833,7 +869,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "%1$u %2$@"
           }
         }
@@ -844,55 +880,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
@@ -916,7 +952,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
@@ -932,9 +968,15 @@
             "value" : "12 sec/E"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "12 sec/E"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
@@ -952,13 +994,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         },
@@ -970,7 +1012,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/E"
           }
         }
@@ -1036,7 +1078,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12 sec/U"
           }
         },
@@ -1079,6 +1121,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "12 sec/U"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "12 sec/U"
           }
         },
@@ -1179,7 +1227,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "12h notation"
           }
         },
@@ -1223,6 +1271,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "12h notation"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notație de 12 ore"
           }
         },
         "ru" : {
@@ -1322,7 +1376,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "24h display"
           }
         },
@@ -1366,6 +1420,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "24h display"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Afișaj 24 de ore"
           }
         },
         "ru" : {
@@ -1465,7 +1525,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "24h notation"
           }
         },
@@ -1509,6 +1569,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "24h notation"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notație de 24 de ore"
           }
         },
         "ru" : {
@@ -1560,55 +1626,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
@@ -1632,7 +1698,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
@@ -1648,9 +1714,15 @@
             "value" : "30 sec/E"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "30 sec/E"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
@@ -1668,13 +1740,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         },
@@ -1686,7 +1758,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/E"
           }
         }
@@ -1752,7 +1824,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "30 sec/U"
           }
         },
@@ -1795,6 +1867,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "30 sec/U"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "30 sec/U"
           }
         },
@@ -1847,55 +1925,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
@@ -1919,7 +1997,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
@@ -1935,9 +2013,15 @@
             "value" : "60 sec/E"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "60 sec/E"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
@@ -1955,13 +2039,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         },
@@ -1973,7 +2057,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/E"
           }
         }
@@ -2039,7 +2123,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "60 sec/U"
           }
         },
@@ -2082,6 +2166,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "60 sec/U"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "60 sec/U"
           }
         },
@@ -2182,7 +2272,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "A blood glucose check reminder has been setup in your pump and is triggered. Please remove it or give your glucose level to the pump"
           }
         },
@@ -2226,6 +2316,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "A blood glucose check reminder has been setup in your pump and is triggered. Please remove it or give your glucose level to the pump"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O reamintire pentru verificarea glicemiei a fost configurată în pompă și este declanșată. Vă rugăm să o eliminați sau să transmiteți nivelul glicemiei pompei."
           }
         },
         "ru" : {
@@ -2325,7 +2421,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive"
           }
         },
@@ -2369,6 +2465,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "A bolus timeout is active. The loop cycle cannot be completed till the timeout is inactive"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "O expirare a bolusului este activă. Ciclul de buclă nu poate fi finalizat până când expirarea nu este inactivă."
           }
         },
         "ru" : {
@@ -2468,7 +2570,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Action has been canceled, because the pump is busy"
           }
         },
@@ -2512,6 +2614,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Action has been canceled, because the pump is busy"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Acțiunea a fost anulată, deoarece pompa este ocupată"
           }
         },
         "ru" : {
@@ -2617,7 +2725,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "After setting up the insulin type and bolus speed, you will see a screen with all found Dana pumps. Select the pump you want to link with %1$@."
           }
         },
@@ -2661,6 +2769,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "After setting up the insulin type and bolus speed, you will see a screen with all found Dana pumps. Select the pump you want to link with %1$@."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "După configurarea tipului de insulină și a vitezei bolusului, veți vedea un ecran cu toate pompele Dana găsite. Selectați pompa pe care doriți să o conectați cu %1$@."
           }
         },
         "ru" : {
@@ -2760,7 +2874,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Alarm beeps"
           }
         },
@@ -2804,6 +2918,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Alarm beeps"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Alarma emite un semnal sonor"
           }
         },
         "ru" : {
@@ -2903,7 +3023,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "An unknown error has occurred during processing the alert from the pump. Please report this"
           }
         },
@@ -2947,6 +3067,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "An unknown error has occurred during processing the alert from the pump. Please report this"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "A apărut o eroare necunoscută în timpul procesării alertei de la pompă. Vă rugăm să raportați acest lucru."
           }
         },
         "ru" : {
@@ -2997,55 +3123,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
@@ -3069,7 +3195,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
@@ -3085,9 +3211,15 @@
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sunteți sigur că doriți să bolusați 5E?"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
@@ -3105,13 +3237,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to bolus 5E?"
           }
         },
@@ -3133,55 +3265,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
@@ -3205,7 +3337,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
@@ -3221,9 +3353,15 @@
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sunteți sigur că vreți să setați bazala temporară la 200% timp de 1 oră?"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
@@ -3241,13 +3379,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to set the temp basal to 200% for 1 hour?"
           }
         },
@@ -3260,7 +3398,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您确定要将温度基础设置为 200% 并持续 1 小时吗？"
+            "value" : "您确定要将临时基础率设置为 200% 并持续 1 小时吗？"
           }
         }
       }
@@ -3318,7 +3456,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Are you sure you want to stop using Dana-i/RS?"
           }
         },
@@ -3362,6 +3500,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Are you sure you want to stop using Dana-i/RS?"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sunteți sigur că nu mai doriți să utilizați pompa Dana-i/RS?"
           }
         },
         "ru" : {
@@ -3461,7 +3605,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Backlight on time"
           }
         },
@@ -3469,6 +3613,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Verifica del periodo"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bakgrunnsbelysning på tid"
           }
         },
         "nb-NO" : {
@@ -3499,6 +3649,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Backlight on time"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Iluminare de fundal la timp"
           }
         },
         "ru" : {
@@ -3574,7 +3730,7 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Basal"
           }
         },
@@ -3598,7 +3754,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Basal"
           }
         },
@@ -3606,6 +3762,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basale"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basal"
           }
         },
         "nb-NO" : {
@@ -3636,6 +3798,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Basal"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bazală"
           }
         },
         "ru" : {
@@ -3677,7 +3845,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "基础"
+            "value" : "基础率"
           }
         }
       }
@@ -3735,7 +3903,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Basal Compare"
           }
         },
@@ -3743,6 +3911,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basale Confronta"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basal sammenligning"
           }
         },
         "nb-NO" : {
@@ -3773,6 +3947,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Basal Compare"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comparație bazală"
           }
         },
         "ru" : {
@@ -3872,7 +4052,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Basal limit reached"
           }
         },
@@ -3880,6 +4060,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Limite basale raggiunto"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basalgrense nådd"
           }
         },
         "nb-NO" : {
@@ -3910,6 +4096,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Basal limit reached"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limita bazală atinsă"
           }
         },
         "ru" : {
@@ -4019,6 +4211,12 @@
             "value" : "Profilo basale"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Basalprofil"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4047,6 +4245,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Perfil Basal"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Profil bazal"
           }
         },
         "ru" : {
@@ -4116,7 +4320,7 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery age"
           }
         },
@@ -4140,7 +4344,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery age"
           }
         },
@@ -4148,6 +4352,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Durata Batteria"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batteri alder"
           }
         },
         "nb-NO" : {
@@ -4164,7 +4374,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery age"
           }
         },
@@ -4178,6 +4388,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Battery age"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vârsta bateriei"
           }
         },
         "ru" : {
@@ -4200,7 +4416,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery age"
           }
         },
@@ -4229,56 +4445,62 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batteriet er tomt. Bytt nå!"
           }
         },
         "nb-NO" : {
@@ -4295,7 +4517,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
           }
         },
@@ -4311,9 +4533,15 @@
             "value" : "Battery is empty. Replace it now!"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bateria este descărcată. Înlocuiți-o acum!"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
           }
         },
@@ -4331,13 +4559,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery is empty. Replace it now!"
           }
         },
@@ -4408,7 +4636,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Battery level"
           }
         },
@@ -4416,6 +4644,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Livello Batteria"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Batterinivå"
           }
         },
         "nb-NO" : {
@@ -4446,6 +4680,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Battery level"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nivelul bateriei"
           }
         },
         "ru" : {
@@ -4545,7 +4785,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Before starting with the pairing process, it is recommended to check, and if needed update, the pump password. You can do this by going to the pump settings -> user settings -> password. The default password is 1234, if this is your password, please consider changing it"
           }
         },
@@ -4553,6 +4793,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Prima di iniziare il processo di accoppiamento, si consiglia di controllare e, se necessario, aggiornare la password del microinfusore. È possibile farlo accedendo alle impostazioni del microinfusore -> impostazioni utente -> password. La password predefinita è 1234; se questa è la vostra password, prendete in considerazione la possibilità di cambiarla."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Før du starter paringsprosessen, anbefales det å sjekke og om nødvendig oppdatere pumpens passord. Du kan gjøre dette ved å gå til pumpeinnstillinger -> brukerinnstillinger -> passord. Standardpassordet er 1234. Hvis dette er passordet ditt, bør du vurdere å endre det."
           }
         },
         "nb-NO" : {
@@ -4583,6 +4829,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Before starting with the pairing process, it is recommended to check, and if needed update, the pump password. You can do this by going to the pump settings -> user settings -> password. The default password is 1234, if this is your password, please consider changing it"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Înainte de a începe procesul de asociere, se recomandă verificarea și, dacă este necesar, actualizarea parolei pompei. Puteți face acest lucru accesând setările pompei -> setările utilizatorului -> parola. Parola implicită este 1234; dacă aceasta este parola dvs., vă rugăm să luați în considerare schimbarea ei."
           }
         },
         "ru" : {
@@ -4682,7 +4934,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Blood glucose Measure"
           }
         },
@@ -4690,6 +4942,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Misura della glicemia"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Blodsukkermåling"
           }
         },
         "nb-NO" : {
@@ -4720,6 +4978,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Blood glucose Measure"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Măsurarea glicemiei"
           }
         },
         "ru" : {
@@ -4829,6 +5093,12 @@
             "value" : "Bolo"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bolus"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -4843,7 +5113,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Bolus"
           }
         },
@@ -4856,6 +5126,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "Bolus"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Bolus"
           }
         },
@@ -4879,7 +5155,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Bolus"
           }
         },
@@ -4956,7 +5232,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Both"
           }
         },
@@ -4964,6 +5240,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Entrambi"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Begge"
           }
         },
         "nb-NO" : {
@@ -4994,6 +5276,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Both"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ambele"
           }
         },
         "ru" : {
@@ -5260,7 +5548,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Cannula age"
           }
         },
@@ -5268,6 +5556,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Età della cannula"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kanyle-alder"
           }
         },
         "nb-NO" : {
@@ -5298,6 +5592,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Cannula age"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vârsta canulei"
           }
         },
         "ru" : {
@@ -5397,7 +5697,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Cannula only"
           }
         },
@@ -5405,6 +5705,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Solo cannula"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kun kanyle"
           }
         },
         "nb-NO" : {
@@ -5435,6 +5741,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Cannula only"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doar canula"
           }
         },
         "ru" : {
@@ -5476,7 +5788,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "仅插管"
+            "value" : "只换导管"
           }
         }
       }
@@ -5541,7 +5853,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Cannula refill"
           }
         },
@@ -5549,6 +5861,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ricarica della cannula"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Påfyll av kanyle"
           }
         },
         "nb-NO" : {
@@ -5579,6 +5897,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Cannula refill"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reumplere canulă"
           }
         },
         "ru" : {
@@ -5678,7 +6002,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Check chaft"
           }
         },
@@ -5686,6 +6010,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Controllare il fusto"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sjekk skaft"
           }
         },
         "nb-NO" : {
@@ -5716,6 +6046,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Check chaft"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Veficați axul"
           }
         },
         "ru" : {
@@ -5815,7 +6151,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Check the pump and try again"
           }
         },
@@ -5823,6 +6159,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Controllare la pompa e riprovare"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontroller pumpen og prøv igjen"
           }
         },
         "nb-NO" : {
@@ -5853,6 +6195,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Check the pump and try again"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificați pompa și încercați din nou"
           }
         },
         "ru" : {
@@ -5952,7 +6300,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Check the reservoir and infus and try again"
           }
         },
@@ -5960,6 +6308,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Controllare il serbatoio e l'infusore e riprovare."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontroller reservoaret og infusjonen, og prøv igjen"
           }
         },
         "nb-NO" : {
@@ -5990,6 +6344,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Check the reservoir and infus and try again"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificați rezervorul și infuzorul și încercați din nou."
           }
         },
         "ru" : {
@@ -6089,7 +6449,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Checked at"
           }
         },
@@ -6097,6 +6457,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Controllato presso"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sjekket på"
           }
         },
         "nb-NO" : {
@@ -6127,6 +6493,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Checked at"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificat la"
           }
         },
         "ru" : {
@@ -6168,7 +6540,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "在"
+            "value" : "同步于"
           }
         }
       }
@@ -6226,7 +6598,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Checksum failed. Try again"
           }
         },
@@ -6234,6 +6606,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Checksum fallito. Riprovare"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kontrollsum mislyktes. Prøv igjen"
           }
         },
         "nb-NO" : {
@@ -6264,6 +6642,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Checksum failed. Try again"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suma de control a eșuat. Încercați din nou."
           }
         },
         "ru" : {
@@ -6373,6 +6757,12 @@
             "value" : "Impostazioni"
           }
         },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Konfigurasjon"
+          }
+        },
         "nb-NO" : {
           "stringUnit" : {
             "state" : "translated",
@@ -6387,7 +6777,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Configuration"
           }
         },
@@ -6401,6 +6791,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ajustes"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurare"
           }
         },
         "ru" : {
@@ -6487,7 +6883,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Connect"
           }
         },
@@ -6501,6 +6897,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Connetti"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Koble til"
           }
         },
         "nb-NO" : {
@@ -6531,6 +6933,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conectar"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectare"
           }
         },
         "ru" : {
@@ -6630,7 +7038,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Connected"
           }
         },
@@ -6638,6 +7046,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Connesso"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tilkoblet"
           }
         },
         "nb-NO" : {
@@ -6668,6 +7082,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conectado"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectat"
           }
         },
         "ru" : {
@@ -6767,7 +7187,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Connecting"
           }
         },
@@ -6811,6 +7231,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Conectando"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Conectare"
           }
         },
         "ru" : {
@@ -6910,7 +7336,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Continue"
           }
         },
@@ -6954,6 +7380,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Continuar"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Continuați"
           }
         },
         "ru" : {
@@ -7053,7 +7485,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Daily limit reached"
           }
         },
@@ -7097,6 +7529,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Daily limit reached"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limita zilnică a fost atinsă"
           }
         },
         "ru" : {
@@ -7172,7 +7610,7 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Dana-i"
           }
         },
@@ -7196,7 +7634,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Dana-i"
           }
         },
@@ -7226,7 +7664,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Dana-i"
           }
         },
@@ -7239,6 +7677,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "Dana-i"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Dana-i"
           }
         },
@@ -7262,7 +7706,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Dana-i"
           }
         },
@@ -7339,7 +7783,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Dana-i/RS Setup"
           }
         },
@@ -7383,6 +7827,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Dana-i/RS Setup"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurarea Dana-i/RS"
           }
         },
         "ru" : {
@@ -7482,7 +7932,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Dana-RS v3 found!"
           }
         },
@@ -7526,6 +7976,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Dana-RS v3 found!"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dana-RS v3 găsită!"
           }
         },
         "ru" : {
@@ -7601,7 +8057,7 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v1"
           }
         },
@@ -7625,7 +8081,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v1"
           }
         },
@@ -7655,7 +8111,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v1"
           }
         },
@@ -7668,6 +8124,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "DanaRS-v1"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "DanaRS-v1"
           }
         },
@@ -7691,7 +8153,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v1"
           }
         },
@@ -7744,7 +8206,7 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v3"
           }
         },
@@ -7768,7 +8230,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v3"
           }
         },
@@ -7798,7 +8260,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v3"
           }
         },
@@ -7811,6 +8273,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "DanaRS-v3"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "DanaRS-v3"
           }
         },
@@ -7834,7 +8302,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DanaRS-v3"
           }
         },
@@ -7918,7 +8386,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "day(s)"
           }
         },
@@ -7962,6 +8430,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "day(s)"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "zi(le)"
           }
         },
         "ru" : {
@@ -8012,55 +8486,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
@@ -8084,7 +8558,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
@@ -8100,9 +8574,15 @@
             "value" : "DEBUG: Bolus action"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEPANARE: Acțiune bolus"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
@@ -8120,13 +8600,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Bolus action"
           }
         },
@@ -8148,55 +8628,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
@@ -8220,7 +8700,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
@@ -8236,9 +8716,15 @@
             "value" : "DEBUG: Temp basal action"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "DEPANARE: Acțiune bazală temporară"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
@@ -8256,13 +8742,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         },
@@ -8274,7 +8760,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "DEBUG: Temp basal action"
           }
         }
@@ -8333,7 +8819,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Delete pump"
           }
         },
@@ -8377,6 +8863,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Delete pump"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ștergeți pompa"
           }
         },
         "ru" : {
@@ -8476,7 +8968,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Delete Pump"
           }
         },
@@ -8520,6 +9012,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Deletar Bomba"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ștergeți pompa"
           }
         },
         "ru" : {
@@ -8619,7 +9117,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Delivery speed"
           }
         },
@@ -8665,6 +9163,12 @@
             "value" : "Delivery speed"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Viteză de livrare"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -8704,7 +9208,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "交付速度"
+            "value" : "推注速率"
           }
         }
       }
@@ -8713,55 +9217,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
@@ -8785,7 +9289,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
@@ -8801,9 +9305,15 @@
             "value" : "Device found!"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dispozitiv găsit!"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
@@ -8821,13 +9331,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Device found!"
           }
         },
@@ -8905,7 +9415,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disable bolus syncing?"
           }
         },
@@ -8949,6 +9459,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Disable bolus syncing?"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dezactivați sincronizarea bolusului?"
           }
         },
         "ru" : {
@@ -8999,13 +9515,13 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnect"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnect"
           }
         },
@@ -9017,37 +9533,37 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnect"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnect"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnect"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnect"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnect"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnect"
           }
         },
@@ -9071,7 +9587,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnect"
           }
         },
@@ -9085,6 +9601,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Disconnect"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deconectați"
           }
         },
         "ru" : {
@@ -9107,7 +9629,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnect"
           }
         },
@@ -9184,7 +9706,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnect from pump"
           }
         },
@@ -9228,6 +9750,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Disconnect from pump"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deconectare pompă"
           }
         },
         "ru" : {
@@ -9327,7 +9855,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnected"
           }
         },
@@ -9371,6 +9899,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Desconectado"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Deconectat"
           }
         },
         "ru" : {
@@ -9470,7 +10004,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Disconnecting..."
           }
         },
@@ -9514,6 +10048,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Disconnecting..."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se deconectează..."
           }
         },
         "ru" : {
@@ -9564,55 +10104,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
@@ -9636,7 +10176,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
@@ -9652,9 +10192,15 @@
             "value" : "Do bolus"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Faceți bolus"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
@@ -9672,13 +10218,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do bolus"
           }
         },
@@ -9749,7 +10295,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Do you wish to receive a notification when the pump is longer disconnected for a specific time?"
           }
         },
@@ -9793,6 +10339,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Do you wish to receive a notification when the pump is longer disconnected for a specific time?"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doriți să primiți o notificare atunci când pompa este deconectată pentru o perioadă mai lungă de timp?"
           }
         },
         "ru" : {
@@ -9879,7 +10431,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Done"
           }
         },
@@ -9915,7 +10467,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Done"
           }
         },
@@ -9926,6 +10478,12 @@
           }
         },
         "pt_BR" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "OK"
+          }
+        },
+        "ro" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "OK"
@@ -10028,7 +10586,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your Dana-i will show a pairing prompt while your iPhone will show a prompt for a pairing code. On you pump, select OK and type the 6-digit code in screen on your iPhone. After that, %1$@ is ready to communicate with your Dana-i"
           }
         },
@@ -10072,6 +10630,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "During the pairing process, your Dana-i will show a pairing prompt while your iPhone will show a prompt for a pairing code. On you pump, select OK and type the 6-digit code in screen on your iPhone. After that, %1$@ is ready to communicate with your Dana-i"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "În timpul procesului de asociere, dispozitivul Dana-i va afișa o solicitare de asociere, în timp ce iPhone-ul va afișa o solicitare pentru un cod de asociere. Pe pompă, selectați OK și introduceți codul de 6 cifre pe ecranul iPhone-ului. După aceea, %1$@ este gata să comunice cu dispozitivul Dana-i."
           }
         },
         "ru" : {
@@ -10129,49 +10693,49 @@
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
@@ -10195,7 +10759,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
@@ -10209,6 +10773,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "În timpul procesului de asociere, DanaRS v1 va afișa o solicitare de asociere, în timp ce iPhone-ul va afișa o solicitare pentru un cod de asociere. Pe pompă, selectați OK și introduceți codul pe iPhone. După aceea, %1$@ este gata să comunice cu DanaRS v1."
           }
         },
         "ru" : {
@@ -10231,7 +10801,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v1"
           }
         },
@@ -10309,7 +10879,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
@@ -10355,6 +10925,12 @@
             "value" : "Durante o processo de emparelhamento, o DanaRS v1 mostrará uma solicitação de emparelhamento, enquanto o iPhone mostrará uma solicitação de código de emparelhamento. Em sua bomba, selecione OK e digite o código em seu iPhone. Depois disso, o Loop estará pronto para se comunicar com o DanaRS v1"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "În timpul procesului de asociere, DanaRS v1 va afișa o solicitare de asociere, în timp ce iPhone-ul va afișa o solicitare pentru un cod de asociere. Pe pompă, selectați OK și introduceți codul pe iPhone. După aceea, Loop este gata să comunice cu DanaRS v1."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10381,7 +10957,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v1 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
@@ -10405,7 +10981,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
@@ -10417,49 +10993,49 @@
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
@@ -10483,7 +11059,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
@@ -10499,15 +11075,21 @@
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "În timpul procesului de asociere, DanaRS v3 va afișa o solicitare de asociere, în timp ce iPhone-ul va afișa o solicitare pentru un cod de asociere. Pe pompă, selectați OK și introduceți codul pe iPhone. După aceea, Loop este gata să comunice cu DanaRS v1."
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
@@ -10519,13 +11101,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for a pairing code. On your pump, select OK and type the code on your iPhone. After that, Loop is ready to communicate with your DanaRS v1"
           }
         },
@@ -10554,49 +11136,49 @@
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
@@ -10620,7 +11202,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
@@ -10634,6 +11216,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "În timpul procesului de asociere, DanaRS v3 va afișa o solicitare de asociere, în timp ce iPhone-ul va afișa o solicitare pentru două coduri de asociere. Pe pompă, selectați OK și introduceți cele două coduri pe iPhone. După aceea, %1$@ este gata să comunice cu DanaRS v3."
           }
         },
         "ru" : {
@@ -10656,7 +11244,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, %1$@ is ready to communicate with your DanaRS v3"
           }
         },
@@ -10740,7 +11328,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3"
           }
         },
@@ -10786,6 +11374,12 @@
             "value" : "Durante o processo de emparelhamento, o DanaRS v3 mostrará uma solicitação de emparelhamento, enquanto o iPhone mostrará uma solicitação de dois códigos de emparelhamento. Em sua bomba, selecione OK e digite os dois códigos em seu iPhone. Depois disso, o Loop estará pronto para se comunicar com o DanaRS v3"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "În timpul procesului de asociere, DanaRS v3 va afișa o solicitare de asociere, în timp ce iPhone-ul va afișa o solicitare pentru două coduri de asociere. Pe pompă, selectați OK și introduceți cele două coduri pe iPhone. După aceea, Loop este gata să comunice cu DanaRS v3."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -10812,7 +11406,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "During the pairing process, your DanaRS v3 will show a pairing prompt while you iPhone will show a prompt for two pairing codes. On your pump, select OK and type the two codes on your iPhone. After that, Loop is ready to communicate with your DanaRS v3"
           }
         },
@@ -10883,7 +11477,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Empty reservoir"
           }
         },
@@ -10891,6 +11485,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Serbatoio vuoto"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tomt reservoar"
           }
         },
         "nb-NO" : {
@@ -10921,6 +11521,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Reservatório vazio"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rezervor gol"
           }
         },
         "ru" : {
@@ -11020,7 +11626,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while connecting to device"
           }
         },
@@ -11028,6 +11634,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Errore durante la connessione al dispositivo"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feil under tilkobling til enheten"
           }
         },
         "nb-NO" : {
@@ -11058,6 +11670,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Error while connecting to device"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eroare în timpul conectării la dispozitiv"
           }
         },
         "ru" : {
@@ -11108,56 +11726,62 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Feil under start av skanning etter enheter..."
           }
         },
         "nb-NO" : {
@@ -11174,7 +11798,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
@@ -11190,15 +11814,21 @@
             "value" : "Error while starting scanning for devices..."
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eroare la pornirea scanării dispozitivelor..."
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
@@ -11210,13 +11840,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Error while starting scanning for devices..."
           }
         },
@@ -11287,7 +11917,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "ERROR: Failed to pair device"
           }
         },
@@ -11331,6 +11961,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "ERROR: Failed to pair device"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "EROARE: Nu s-a reușit asocierea dispozitivului"
           }
         },
         "ru" : {
@@ -11430,7 +12066,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to adjust basal"
           }
         },
@@ -11438,6 +12074,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mancata regolazione della basale"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke justere basal"
           }
         },
         "nb-NO" : {
@@ -11468,6 +12110,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Failed to adjust basal"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a putut ajusta bazala"
           }
         },
         "ru" : {
@@ -11509,7 +12157,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未能调整基础代谢率"
+            "value" : "调整基础率失败"
           }
         }
       }
@@ -11567,7 +12215,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to adjust pump time"
           }
         },
@@ -11575,6 +12223,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mancata regolazione del tempo di pompaggio"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke justere pumpetiden"
           }
         },
         "nb-NO" : {
@@ -11605,6 +12259,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Failed to adjust pump time"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a reușit setarei timpului de pe pompă"
           }
         },
         "ru" : {
@@ -11704,7 +12364,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to adjust suspension"
           }
         },
@@ -11712,6 +12372,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Mancata regolazione della sospensione"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klarte ikke å justere suspensjonen"
           }
         },
         "nb-NO" : {
@@ -11742,6 +12408,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Failed to adjust suspension"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a putut ajusta suspendarea"
           }
         },
         "ru" : {
@@ -11848,7 +12520,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to adjust temp basal"
           }
         },
@@ -11856,6 +12528,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impossibile regolare la temperatura basale"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke justere midlertidig basal"
           }
         },
         "nb-NO" : {
@@ -11886,6 +12564,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Failed to adjust temp basal"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a putut ajusta valoarea bazală temporară"
           }
         },
         "ru" : {
@@ -11927,7 +12611,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "未能调整基础温度"
+            "value" : "调整临时基础率失败"
           }
         }
       }
@@ -11985,7 +12669,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to generate Dana basal program"
           }
         },
@@ -11993,6 +12677,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impossibile generare il programma Dana basal"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke generere Dana basalprogram"
           }
         },
         "nb-NO" : {
@@ -12023,6 +12713,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Failed to generate Dana basal program"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a putut genera programul bazal Dana"
           }
         },
         "ru" : {
@@ -12064,7 +12760,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "生成达纳基础程序失败"
+            "value" : "生成 Dana 基础率程序失败"
           }
         }
       }
@@ -12129,7 +12825,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to make a connection"
           }
         },
@@ -12137,6 +12833,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impossibile stabilire una connessione"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke opprette en tilkobling"
           }
         },
         "nb-NO" : {
@@ -12167,6 +12869,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Failed to make a connection"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a reușit stabilirea unei conexiuni"
           }
         },
         "ru" : {
@@ -12218,56 +12926,62 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke koble til "
           }
         },
         "nb-NO" : {
@@ -12284,7 +12998,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
@@ -12300,15 +13014,21 @@
             "value" : "Failed to pair to "
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a putut asocia cu "
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
@@ -12320,13 +13040,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to pair to "
           }
         },
@@ -12391,7 +13111,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to prime the cannula. Please try again later"
           }
         },
@@ -12399,6 +13119,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Non è stato possibile adescare la cannula. Riprovare più tardi"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke klargjøre kanylen. Prøv igjen senere."
           }
         },
         "nb-NO" : {
@@ -12429,6 +13155,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Failed to prime the cannula. Please try again later"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amorsarea canulei nu a reușit. Vă rugăm să încercați din nou mai târziu."
           }
         },
         "ru" : {
@@ -12522,7 +13254,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to prime the tube. Please try again later"
           }
         },
@@ -12530,6 +13262,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Non è stato possibile adescare il tubo. Riprovare più tardi"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke klargjøre slangen. Vennligst prøv igjen senere"
           }
         },
         "nb-NO" : {
@@ -12560,6 +13298,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Failed to prime the tube. Please try again later"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Amorsarea tubului a eșuat. Vă rugăm să încercați din nou mai târziu."
           }
         },
         "ru" : {
@@ -12653,7 +13397,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Failed to set reservoir amount. Re-sync pump data and try again please"
           }
         },
@@ -12661,6 +13405,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impossibile impostare la quantità di serbatoio. Risincronizzare i dati della pompa e riprovare."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Kunne ikke angi reservoarmengde. Synkroniser pumpedataene på nytt og prøv igjen."
           }
         },
         "nb-NO" : {
@@ -12691,6 +13441,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Failed to set reservoir amount. Re-sync pump data and try again please"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu s-a putut seta cantitatea din rezervor. Resincronizați datele pompei și încercați din nou."
           }
         },
         "ru" : {
@@ -12790,7 +13546,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Fill in password"
           }
         },
@@ -12798,6 +13554,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Inserire la password"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fyll inn passord"
           }
         },
         "nb-NO" : {
@@ -12828,6 +13590,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Fill in password"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Completați parola"
           }
         },
         "ru" : {
@@ -12927,7 +13695,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Finish"
           }
         },
@@ -12935,6 +13703,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Finitura"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fullfør"
           }
         },
         "nb-NO" : {
@@ -12965,6 +13739,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Finish"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Finalizare"
           }
         },
         "ru" : {
@@ -13064,7 +13844,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Firmware version"
           }
         },
@@ -13072,6 +13852,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Versione del firmware"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fastvareversjon"
           }
         },
         "nb-NO" : {
@@ -13102,6 +13888,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Firmware version"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Versiune firmware"
           }
         },
         "ru" : {
@@ -13201,7 +13993,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Found Dana-i/RS pumps"
           }
         },
@@ -13209,6 +14001,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Trovate le pompe Dana-i/RS"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Fant Dana-i/RS-pumper"
           }
         },
         "nb-NO" : {
@@ -13239,6 +14037,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Found Dana-i/RS pumps"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pompe Dana-i/RS găsite"
           }
         },
         "ru" : {
@@ -13338,7 +14142,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Hardware model"
           }
         },
@@ -13346,6 +14150,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modello hardware"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maskinvaremodell"
           }
         },
         "nb-NO" : {
@@ -13376,6 +14186,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Hardware model"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Modelul hardware"
           }
         },
         "ru" : {
@@ -13446,7 +14262,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Insulin\nAusgesetzt"
+            "value" : "Insulin\nUnterbrochen"
           }
         },
         "es" : {
@@ -13475,7 +14291,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin\nSuspended"
           }
         },
@@ -13521,6 +14337,12 @@
             "value" : "Insulina\nSuspenso"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insulină \nSuspendată"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -13547,7 +14369,7 @@
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin\nSuspended"
           }
         },
@@ -13618,7 +14440,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin Delivery"
           }
         },
@@ -13626,6 +14448,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulina Somministrata"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insulintilførsel"
           }
         },
         "nb-NO" : {
@@ -13642,7 +14470,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin Delivery"
           }
         },
@@ -13656,6 +14484,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Insulin Delivery"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Administrarea insulinei"
           }
         },
         "ru" : {
@@ -13697,7 +14531,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "胰岛素输送"
+            "value" : "胰岛素推注"
           }
         }
       }
@@ -13755,7 +14589,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin Remaining"
           }
         },
@@ -13763,6 +14597,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulina Rimanente"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Gjenværende insulin"
           }
         },
         "nb-NO" : {
@@ -13779,7 +14619,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin Remaining"
           }
         },
@@ -13793,6 +14633,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Insulin Remaining"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insulină rămasă"
           }
         },
         "ru" : {
@@ -13892,7 +14738,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin Suspended"
           }
         },
@@ -13900,6 +14746,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Insulina Sospesa"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insulin suspendert"
           }
         },
         "nb-NO" : {
@@ -13916,7 +14768,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin Suspended"
           }
         },
@@ -13930,6 +14782,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Insulin Suspended"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Administrarea insulinei suspendată"
           }
         },
         "ru" : {
@@ -14029,7 +14887,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin Type"
           }
         },
@@ -14037,6 +14895,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tipo di Insulina"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insulintype"
           }
         },
         "nb-NO" : {
@@ -14053,7 +14917,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Insulin Type"
           }
         },
@@ -14067,6 +14931,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tipo de Insulina"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipul de insulină"
           }
         },
         "ru" : {
@@ -14166,7 +15036,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Last sync"
           }
         },
@@ -14174,6 +15044,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ultima sincronizzazione"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Siste synkronisering"
           }
         },
         "nb-NO" : {
@@ -14204,6 +15080,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Last sync"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ultima sincronizare"
           }
         },
         "ru" : {
@@ -14303,7 +15185,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Lcd on time"
           }
         },
@@ -14311,6 +15193,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tempo di accensione dell'Lcd"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lcd på tid"
           }
         },
         "nb-NO" : {
@@ -14341,6 +15229,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Lcd on time"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "LCD la timp"
           }
         },
         "ru" : {
@@ -14442,12 +15336,12 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "loading"
+            "value" : "טוען"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "loading"
           }
         },
@@ -14491,6 +15385,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "loading"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se încarcă..."
           }
         },
         "ru" : {
@@ -14597,7 +15497,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Loading"
           }
         },
@@ -14641,6 +15541,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Loading"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Se încarcă..."
           }
         },
         "ru" : {
@@ -14740,7 +15646,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Low pump battery"
           }
         },
@@ -14784,6 +15690,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Low pump battery"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baterie pompă descărcată"
           }
         },
         "ru" : {
@@ -14883,7 +15795,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Low reservoir reminder"
           }
         },
@@ -14927,6 +15839,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Low reservoir reminder"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notificare rezervor scăzut"
           }
         },
         "ru" : {
@@ -15026,7 +15944,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Manually sync Pump time"
           }
         },
@@ -15070,6 +15988,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Manually sync Pump time"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizare manuală a orei pompei"
           }
         },
         "ru" : {
@@ -15169,7 +16093,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Missed Blood glucose check"
           }
         },
@@ -15213,6 +16137,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Missed Blood glucose check"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Verificarea glicemiei ratată"
           }
         },
         "ru" : {
@@ -15312,7 +16242,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Nightly pump time sync"
           }
         },
@@ -15356,6 +16286,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Nightly pump time sync"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizare nocturnă a orei pompei"
           }
         },
         "ru" : {
@@ -15442,7 +16378,7 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "No"
           }
         },
@@ -15478,7 +16414,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "No"
           }
         },
@@ -15492,6 +16428,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "No"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu"
           }
         },
         "ru" : {
@@ -15514,7 +16456,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "No"
           }
         },
@@ -15586,12 +16528,12 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "No Insulin"
+            "value" : "אין אינסולין"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "No Insulin"
           }
         },
@@ -15634,6 +16576,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "No Insulin"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "No Insulin"
           }
         },
@@ -15740,7 +16688,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "No, just disconnect"
           }
         },
@@ -15784,6 +16732,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "No, just disconnect"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu, doar deconectează-te"
           }
         },
         "ru" : {
@@ -15883,7 +16837,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "No, Keep as is"
           }
         },
@@ -15927,6 +16881,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "No, Keep as is"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu, păstrați așa cum este"
           }
         },
         "ru" : {
@@ -16026,7 +16986,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "No, Keep Pump As Is"
           }
         },
@@ -16056,7 +17016,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "No, Keep Pump As Is"
           }
         },
@@ -16070,6 +17030,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "No, Keep Pump As Is"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu, păstrați pompa așa cum este"
           }
         },
         "ru" : {
@@ -16139,7 +17105,7 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
@@ -16163,13 +17129,13 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
@@ -16193,7 +17159,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
@@ -16207,6 +17173,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "NOTĂ: DanaRS v1 nu este (încă) compatibilă. Dacă aveți o pompă DanaRS v1 disponibilă pentru testare, vă rugăm să-l contactați pe Bastiaan Verhaar!"
           }
         },
         "ru" : {
@@ -16229,7 +17201,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "NOTE: The DanaRS v1 is not supported (yet). If you have a DanaRS v1 pump available for testing, please contact Bastiaan Verhaar!"
           }
         },
@@ -16306,7 +17278,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Note: You Dana pump has a special setting which allows you to silence your Dana pump beeps. To enable this, please contact your Dana distributor"
           }
         },
@@ -16352,6 +17324,12 @@
             "value" : "Note: You Dana pump has a special setting which allows you to silence your Dana pump beeps. To enable this, please contact your Dana distributor"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notă: Pompa dumneavoastră Dana are o setare specială care vă permite să dezactivați semnalele sonore ale pompei Dana. Pentru a activa această opțiune, vă rugăm să contactați distribuitorul Dana."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -16391,7 +17369,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "注：您的德纳泵有一个特殊设置，允许您将德纳泵的蜂鸣声静音。要启用此功能，请联系您的德纳经销商。"
+            "value" : "注：您的 Dana 泵有一个特殊设置，允许您将德纳泵的蜂鸣声静音。要启用此功能，请联系您的 Dana 经销商。"
           }
         }
       }
@@ -16449,7 +17427,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Occlusion"
           }
         },
@@ -16493,6 +17471,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Occlusion"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ocluzie"
           }
         },
         "ru" : {
@@ -16592,7 +17576,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Off"
           }
         },
@@ -16636,6 +17620,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Off"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oprit"
           }
         },
         "ru" : {
@@ -16735,7 +17725,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "OK"
           }
         },
@@ -16848,55 +17838,61 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
+            "value" : "Oke"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Oke"
           }
         },
@@ -16914,7 +17910,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
@@ -16930,15 +17926,21 @@
             "value" : "Oke"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ok"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
         "sk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
@@ -16950,13 +17952,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         },
@@ -16968,7 +17970,7 @@
         },
         "zh-Hans" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Oke"
           }
         }
@@ -17027,7 +18029,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "On"
           }
         },
@@ -17035,6 +18037,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Acceso"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "På"
           }
         },
         "nb-NO" : {
@@ -17065,6 +18073,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Ligado"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pornit"
           }
         },
         "ru" : {
@@ -17171,7 +18185,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Only Automatic Bolus is supported"
           }
         },
@@ -17179,6 +18193,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "È supportato solo il bolo automatico"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bare automatisk bolus støttes"
           }
         },
         "nb-NO" : {
@@ -17209,6 +18229,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Only Automatic Bolus is supported"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Doar bolusul automat este acceptat"
           }
         },
         "ru" : {
@@ -17308,7 +18334,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Password DanaRS v1"
           }
         },
@@ -17316,6 +18342,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Password DanaRS v1"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Passord DanaRS v1"
           }
         },
         "nb-NO" : {
@@ -17346,6 +18378,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Password DanaRS v1"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Parolă DanaRS v1"
           }
         },
         "ru" : {
@@ -17445,11 +18483,17 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pin 1"
           }
         },
         "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin 1"
+          }
+        },
+        "nb" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pin 1"
@@ -17469,7 +18513,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pin 1"
           }
         },
@@ -17483,6 +18527,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin 1"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pinul 1"
           }
         },
         "ru" : {
@@ -17505,7 +18555,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pin 1"
           }
         },
@@ -17582,11 +18632,17 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pin 2"
           }
         },
         "it" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin 2"
+          }
+        },
+        "nb" : {
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pin 2"
@@ -17606,7 +18662,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pin 2"
           }
         },
@@ -17620,6 +18676,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Pin 2"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pinul 2"
           }
         },
         "ru" : {
@@ -17642,7 +18704,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pin 2"
           }
         },
@@ -17726,7 +18788,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pincode required"
           }
         },
@@ -17734,6 +18796,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Pincode richiesto"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pin-kode kreves"
           }
         },
         "nb-NO" : {
@@ -17764,6 +18832,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Pincode required"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cod PIN necesar"
           }
         },
         "ru" : {
@@ -17870,7 +18944,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Please consider changing your dosing strategy in the setting menu"
           }
         },
@@ -17878,6 +18952,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Considerare la possibilità di modificare la strategia di dosaggio nel menu delle impostazioni."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vennligst vurder å endre doseringsstrategien din i innstillingsmenyen"
           }
         },
         "nb-NO" : {
@@ -17908,6 +18988,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Please consider changing your dosing strategy in the setting menu"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vă rugăm să luați în considerare schimbarea strategiei de dozare în meniul de setări."
           }
         },
         "ru" : {
@@ -17959,56 +19045,62 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Prim mengde"
           }
         },
         "nb-NO" : {
@@ -18025,7 +19117,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
           }
         },
@@ -18041,9 +19133,15 @@
             "value" : "Prime amount"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cantitate de amorsare"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
           }
         },
@@ -18061,13 +19159,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Prime amount"
           }
         },
@@ -18138,7 +19236,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump battery 0%"
           }
         },
@@ -18146,6 +19244,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Batteria della pompa 0%"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpebatteri 0 %"
           }
         },
         "nb-NO" : {
@@ -18176,6 +19280,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Pump battery 0%"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Baterie pompă 0%"
           }
         },
         "ru" : {
@@ -18282,7 +19392,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump battery is empty. Replace it now!"
           }
         },
@@ -18290,6 +19400,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La batteria della pompa è scarica. Sostituitela subito!"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpebatteriet er tomt. Bytt den ut nå!"
           }
         },
         "nb-NO" : {
@@ -18320,6 +19436,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Pump battery is empty. Replace it now!"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bateria pompei este descărcată. Înlocuiți-o acum!"
           }
         },
         "ru" : {
@@ -18419,7 +19541,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump battery needs to be replaced soon"
           }
         },
@@ -18427,6 +19549,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La batteria della pompa deve essere sostituita al più presto"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpebatteriet må skiftes snart"
           }
         },
         "nb-NO" : {
@@ -18457,6 +19585,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Pump battery needs to be replaced soon"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bateria pompei trebuie înlocuită în curând"
           }
         },
         "ru" : {
@@ -18556,7 +19690,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump error"
           }
         },
@@ -18564,6 +19698,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Errore della pompa"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpefeil"
           }
         },
         "nb-NO" : {
@@ -18594,6 +19734,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Pump error"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eroare pompă"
           }
         },
         "ru" : {
@@ -18693,7 +19839,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump information"
           }
         },
@@ -18701,6 +19847,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Informazioni sulla pompa"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpeinformasjon"
           }
         },
         "nb-NO" : {
@@ -18731,6 +19883,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Pump information"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Informații despre pompă"
           }
         },
         "ru" : {
@@ -18782,56 +19940,62 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpen er frakoblet"
           }
         },
         "nb-NO" : {
@@ -18848,7 +20012,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
           }
         },
@@ -18864,9 +20028,15 @@
             "value" : "Pump is disconnected"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pompa este deconectată"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
           }
         },
@@ -18884,13 +20054,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is disconnected"
           }
         },
@@ -18961,7 +20131,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump is still disconnected"
           }
         },
@@ -18969,6 +20139,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La pompa è ancora scollegata"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpen er fortsatt frakoblet"
           }
         },
         "nb-NO" : {
@@ -18999,6 +20175,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Pump is still disconnected"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pompa este încă deconectată"
           }
         },
         "ru" : {
@@ -19098,7 +20280,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump name"
           }
         },
@@ -19106,6 +20288,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Nome della pompa"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Navn på pumpen"
           }
         },
         "nb-NO" : {
@@ -19136,6 +20324,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Pump name"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Numele pompei"
           }
         },
         "ru" : {
@@ -19235,7 +20429,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump shutdown"
           }
         },
@@ -19243,6 +20437,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Arresto della pompa"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avstengning av pumpe"
           }
         },
         "nb-NO" : {
@@ -19273,6 +20473,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Pump shutdown"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oprirea pompei"
           }
         },
         "ru" : {
@@ -19372,7 +20578,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Pump time"
           }
         },
@@ -19380,6 +20586,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tempo di pompaggio"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpetid"
           }
         },
         "nb-NO" : {
@@ -19410,6 +20622,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Pump time"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ora pompei"
           }
         },
         "ru" : {
@@ -19516,7 +20734,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Re-enable bolus syncing?"
           }
         },
@@ -19524,6 +20742,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Riabilitare la sincronizzazione del bolo?"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Aktivere bolussynkronisering på nytt?"
           }
         },
         "nb-NO" : {
@@ -19554,6 +20778,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Re-enable bolus syncing?"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reactivați sincronizarea bolusului?"
           }
         },
         "ru" : {
@@ -19653,7 +20883,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Received invalid hex strings. Try again"
           }
         },
@@ -19697,6 +20927,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Received invalid hex strings. Try again"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Am primit șiruri hexadecimale nevalide. Încercați din nou."
           }
         },
         "ru" : {
@@ -19796,7 +21032,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Received invalid pincode lengths. Try again"
           }
         },
@@ -19840,6 +21076,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Received invalid pincode lengths. Try again"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Am primit lungimi de cod PIN nevalide. Încercați din nou."
           }
         },
         "ru" : {
@@ -19891,55 +21133,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
@@ -19963,7 +21205,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
@@ -19979,9 +21221,15 @@
             "value" : "Reconnect to pump"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reconectare la pompă"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
@@ -19999,13 +21247,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect to pump"
           }
         },
@@ -20083,7 +21331,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnect tp pump"
           }
         },
@@ -20127,6 +21375,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Reconnect tp pump"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reconectare la pompă"
           }
         },
         "ru" : {
@@ -20226,7 +21480,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnecting..."
           }
         },
@@ -20256,7 +21510,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reconnecting..."
           }
         },
@@ -20270,6 +21524,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Reconnecting..."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reconectare..."
           }
         },
         "ru" : {
@@ -20369,7 +21629,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Refill amount"
           }
         },
@@ -20413,6 +21673,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Refill amount"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cantitate de reumplere"
           }
         },
         "ru" : {
@@ -20512,7 +21778,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Remaining insulin level"
           }
         },
@@ -20556,6 +21822,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Remaining insulin level"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nivelul de insulină rămas"
           }
         },
         "ru" : {
@@ -20655,7 +21927,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Remove Pump"
           }
         },
@@ -20685,7 +21957,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Remove Pump"
           }
         },
@@ -20699,6 +21971,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Remove Pump"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ștergeți pompa"
           }
         },
         "ru" : {
@@ -20798,7 +22076,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reservoir age"
           }
         },
@@ -20844,6 +22122,12 @@
             "value" : "Reservoir age"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vârsta rezervorului"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -20883,7 +22167,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "水库年龄"
+            "value" : "储药器使用时间"
           }
         }
       }
@@ -20935,7 +22219,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reservoir amount"
           }
         },
@@ -20979,6 +22263,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Reservoir amount"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cantitatea rezervorului"
           }
         },
         "ru" : {
@@ -21078,7 +22368,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reservoir and cannula"
           }
         },
@@ -21124,6 +22414,12 @@
             "value" : "Reservoir and cannula"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rezervor și canulă"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21163,7 +22459,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "蓄水池和插管"
+            "value" : "储药器和导管"
           }
         }
       }
@@ -21221,7 +22517,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reservoir is empty. Replace it now!"
           }
         },
@@ -21267,6 +22563,12 @@
             "value" : "Reservoir is empty. Replace it now!"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rezervorul este gol. Înlocuiți-l acum!"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21306,7 +22608,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "蓄水池已空。立即更换！"
+            "value" : "储药器已空。请立即更换！"
           }
         }
       }
@@ -21364,7 +22666,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Reservoir/cannula refill"
           }
         },
@@ -21408,6 +22710,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Reservoir/cannula refill"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reumplere rezervor/canulă"
           }
         },
         "ru" : {
@@ -21478,7 +22786,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Lebenslauf"
+            "value" : "fortsetzen"
           }
         },
         "es" : {
@@ -21550,6 +22858,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "Resume"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Resume"
           }
         },
@@ -21656,7 +22970,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Resume delivery"
           }
         },
@@ -21702,6 +23016,12 @@
             "value" : "Resume delivery"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reluați administrarea de insulină"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21741,7 +23061,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "简历交付"
+            "value" : "恢复推注"
           }
         }
       }
@@ -21845,6 +23165,12 @@
             "value" : "Salvar"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Salvează"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -21893,55 +23219,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
@@ -21965,7 +23291,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
@@ -21981,9 +23307,15 @@
             "value" : "Scan"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scanare"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
@@ -22001,13 +23333,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scan"
           }
         },
@@ -22078,7 +23410,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scanning"
           }
         },
@@ -22108,7 +23440,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scanning"
           }
         },
@@ -22122,6 +23454,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Scanning"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Scanare"
           }
         },
         "ru" : {
@@ -22221,7 +23559,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scheduled Basal"
           }
         },
@@ -22251,7 +23589,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scheduled Basal"
           }
         },
@@ -22265,6 +23603,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Scheduled Basal"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bazală programată"
           }
         },
         "ru" : {
@@ -22364,7 +23708,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Scroll function"
           }
         },
@@ -22408,6 +23752,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Scroll function"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Funcția de derulare"
           }
         },
         "ru" : {
@@ -22483,7 +23833,7 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "sec"
           }
         },
@@ -22502,12 +23852,12 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "sec"
+            "value" : "שניה"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "sec"
           }
         },
@@ -22515,6 +23865,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "sec"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "sek"
           }
         },
         "nb-NO" : {
@@ -22544,6 +23900,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "sec"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "sec"
           }
         },
@@ -22596,55 +23958,55 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin type"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin type"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin type"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin type"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin type"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin type"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin type"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin type"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin type"
           }
         },
@@ -22668,7 +24030,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin type"
           }
         },
@@ -22682,6 +24044,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Select insulin type"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selectați tipul de insulină"
           }
         },
         "ru" : {
@@ -22704,7 +24072,7 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin type"
           }
         },
@@ -22788,7 +24156,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select insulin Type"
           }
         },
@@ -22832,6 +24200,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Select insulin Type"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selectați tipul de insulină"
           }
         },
         "ru" : {
@@ -22931,7 +24305,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select the type of insulin that you will be using in this pump"
           }
         },
@@ -22975,6 +24349,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Select the type of insulin that you will be using in this pump"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selectați tipul de insulină pe care îl veți utiliza în această pompă."
           }
         },
         "ru" : {
@@ -23062,13 +24442,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select the type of insulin that you will be using in this pump."
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select the type of insulin that you will be using in this pump."
           }
         },
@@ -23112,6 +24492,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Select the type of insulin that you will be using in this pump."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selectați tipul de insulină pe care îl veți utiliza în această pompă."
           }
         },
         "ru" : {
@@ -23211,7 +24597,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Select your pump"
           }
         },
@@ -23255,6 +24641,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Select your pump"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Selectați pompa"
           }
         },
         "ru" : {
@@ -23354,7 +24746,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Set reminder for disconnect"
           }
         },
@@ -23398,6 +24790,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Set reminder for disconnect"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setați un memento pentru deconectare"
           }
         },
         "ru" : {
@@ -23504,7 +24902,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Set the basal profile the pump should use. Note, that it will overwrite the profile that is in the pump, with the one in %1$@"
           }
         },
@@ -23550,6 +24948,12 @@
             "value" : "Set the basal profile the pump should use. Note, that it will overwrite the profile that is in the pump, with the one in %1$@"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setați profilul bazal pe care pompa ar trebui să îl utilizeze. Rețineți că acesta va suprascrie profilul din pompă cu cel din %1$@"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23589,7 +24993,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "设置泵应使用的基础曲线。注意，它将用 %1$@中的配置文件覆盖泵中的配置文件。"
+            "value" : "设置泵应使用的基础配置文件。注意，它将用 %1$@中的配置文件覆盖泵中的配置文件。"
           }
         }
       }
@@ -23654,7 +25058,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setting temp basal is not supported at this time"
           }
         },
@@ -23700,6 +25104,12 @@
             "value" : "Setting temp basal is not supported at this time"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Setarea bazalei temporare nu este acceptată în acest moment"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -23739,7 +25149,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "目前不支持设置基础温度"
+            "value" : "目前不支持设置临时基础率"
           }
         }
       }
@@ -23797,7 +25207,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setting up Dana-i"
           }
         },
@@ -23805,6 +25215,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impostazione di Dana-i"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sette opp Dana-i"
           }
         },
         "nb-NO" : {
@@ -23835,6 +25251,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Setting up Dana-i"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurarea Dana-i"
           }
         },
         "ru" : {
@@ -23934,7 +25356,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setting up DanaRS v1"
           }
         },
@@ -23942,6 +25364,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impostazione di DanaRS v1"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sette opp DanaRS v1"
           }
         },
         "nb-NO" : {
@@ -23972,6 +25400,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Setting up DanaRS v1"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurarea DanaRS v1"
           }
         },
         "ru" : {
@@ -24071,7 +25505,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setting up DanaRS v3"
           }
         },
@@ -24079,6 +25513,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Impostazione di DanaRS v3"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sette opp DanaRS v3"
           }
         },
         "nb-NO" : {
@@ -24109,6 +25549,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Setting up DanaRS v3"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurarea DanaRS v3"
           }
         },
         "ru" : {
@@ -24160,7 +25606,7 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setup Complete"
           }
         },
@@ -24184,7 +25630,7 @@
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setup Complete"
           }
         },
@@ -24196,13 +25642,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setup Complete"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setup Complete"
           }
         },
@@ -24210,6 +25656,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Installazione Completata"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Oppsettet er fullført"
           }
         },
         "nb-NO" : {
@@ -24226,7 +25678,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Setup Complete"
           }
         },
@@ -24240,6 +25692,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Setup Complete"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Configurare finalizată"
           }
         },
         "ru" : {
@@ -24339,7 +25797,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Share Dana pump logs"
           }
         },
@@ -24347,6 +25805,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Condividi i registri della pompa Dana"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Del Dana-pumpelogger"
           }
         },
         "nb-NO" : {
@@ -24377,6 +25841,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Share Dana pump logs"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Partajați jurnalele pompei Dana"
           }
         },
         "ru" : {
@@ -24418,7 +25888,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "分享德纳泵日志"
+            "value" : "分享 Dana 泵日志"
           }
         }
       }
@@ -24476,7 +25946,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Should time be display in 12h or 24h"
           }
         },
@@ -24484,6 +25954,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "L'orario dovrebbe essere visualizzato in 12 o 24 ore?"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Skal tiden vises om 12 timer eller 24 timer"
           }
         },
         "nb-NO" : {
@@ -24514,6 +25990,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Should time be display in 12h or 24h"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ar trebui afișată ora în format de 12 ore sau 24 de ore?"
           }
         },
         "ru" : {
@@ -24613,7 +26095,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Signal Loss"
           }
         },
@@ -24656,6 +26138,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "Signal Loss"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Signal Loss"
           }
         },
@@ -24762,7 +26250,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Sound"
           }
         },
@@ -24770,6 +26258,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Suono"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Lyd"
           }
         },
         "nb-NO" : {
@@ -24800,6 +26294,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Sound"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sunet"
           }
         },
         "ru" : {
@@ -24899,7 +26399,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Status"
           }
         },
@@ -25061,7 +26561,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Step 1: Prime cannula"
           }
         },
@@ -25069,6 +26569,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fase 1: adescare la cannula"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trinn 1: Prime-kanyle"
           }
         },
         "nb-NO" : {
@@ -25099,6 +26605,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Step 1: Prime cannula"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pasul 1: Amorsarea canulei"
           }
         },
         "ru" : {
@@ -25140,7 +26652,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "步骤 1：插管填料"
+            "value" : "步骤 1：导管排气"
           }
         }
       }
@@ -25192,7 +26704,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Step 1: Set reservoir level"
           }
         },
@@ -25200,6 +26712,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fase 1: Impostazione del livello del serbatoio"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trinn 1: Still inn reservoarnivået"
           }
         },
         "nb-NO" : {
@@ -25230,6 +26748,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Step 1: Set reservoir level"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pasul 1: Setați nivelul rezervorului"
           }
         },
         "ru" : {
@@ -25271,7 +26795,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "步骤 1：设置蓄水池水位"
+            "value" : "步骤 1：设置储药器药量"
           }
         }
       }
@@ -25323,7 +26847,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Step 2: Set tube refill amount"
           }
         },
@@ -25331,6 +26855,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Fase 2: Impostazione della quantità di ricarica del tubo"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trinn 2: Still inn påfyllingsmengde for tube"
           }
         },
         "nb-NO" : {
@@ -25361,6 +26891,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Step 2: Set tube refill amount"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pasul 2: Setați cantitatea de reumplere a tubului"
           }
         },
         "ru" : {
@@ -25402,7 +26938,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "步骤 2：设置软管填充量"
+            "value" : "步骤 2：设置导管充注量"
           }
         }
       }
@@ -25411,13 +26947,13 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
           }
         },
@@ -25429,38 +26965,44 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stopp bolus"
           }
         },
         "nb-NO" : {
@@ -25477,7 +27019,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
           }
         },
@@ -25493,9 +27035,15 @@
             "value" : "Stop bolus"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opriți bolusul"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
           }
         },
@@ -25513,13 +27061,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop bolus"
           }
         },
@@ -25590,7 +27138,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Stop temp basal"
           }
         },
@@ -25598,6 +27146,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Interruzione della temperatura basale"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Stopp midlertidig basal"
           }
         },
         "nb-NO" : {
@@ -25628,6 +27182,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Stop temp basal"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opriți bazala temporară"
           }
         },
         "ru" : {
@@ -25669,7 +27229,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "停止基础温度"
+            "value" : "停止临时基础率"
           }
         }
       }
@@ -25698,7 +27258,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "aussetzen."
+            "value" : "unterbrechen"
           }
         },
         "es" : {
@@ -25770,6 +27330,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "Suspend"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Suspend"
           }
         },
@@ -25876,7 +27442,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Suspend delivery"
           }
         },
@@ -25884,6 +27450,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sospendere la consegna"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Avbryt levering"
           }
         },
         "nb-NO" : {
@@ -25914,6 +27486,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Suspend delivery"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Suspendați livrarea"
           }
         },
         "ru" : {
@@ -25955,7 +27533,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "暂停交付"
+            "value" : "暂停推注"
           }
         }
       }
@@ -26013,7 +27591,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Sync pump data"
           }
         },
@@ -26021,6 +27599,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Sincronizzazione dei dati della pompa"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Synkroniser pumpedata"
           }
         },
         "nb-NO" : {
@@ -26051,6 +27635,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Sync pump data"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sincronizați datele pompei"
           }
         },
         "ru" : {
@@ -26101,13 +27691,13 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "temp basal"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "temp basal"
           }
         },
@@ -26119,31 +27709,31 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "temp basal"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "temp basal"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "temp basal"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "temp basal"
+            "state" : "translated",
+            "value" : "קצב בסיסי זמני"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "temp basal"
           }
         },
@@ -26151,6 +27741,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basale temporanea"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "midlertidig basal"
           }
         },
         "nb-NO" : {
@@ -26167,7 +27763,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "temp basal"
           }
         },
@@ -26183,9 +27779,15 @@
             "value" : "temp basal"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bazală temporară"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "temp basal"
           }
         },
@@ -26203,13 +27805,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "temp basal"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "temp basal"
           }
         },
@@ -26280,7 +27882,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Temp Basal"
           }
         },
@@ -26288,6 +27890,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Basale temporanea"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Midlertidig basal"
           }
         },
         "nb-NO" : {
@@ -26304,7 +27912,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Temp Basal"
           }
         },
@@ -26318,6 +27926,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Temp Basal"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bazală temporară"
           }
         },
         "ru" : {
@@ -26359,7 +27973,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "基础温度"
+            "value" : "临时基础率"
           }
         }
       }
@@ -26417,7 +28031,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The Dana pumps support different delivery speeds. You can set it up here"
           }
         },
@@ -26425,6 +28039,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le pompe Dana supportano diverse velocità di erogazione. È possibile impostarle qui"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dana-pumpene støtter forskjellige leveringshastigheter. Du kan sette den opp her"
           }
         },
         "nb-NO" : {
@@ -26455,6 +28075,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "The Dana pumps support different delivery speeds. You can set it up here"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pompele Dana acceptă diferite viteze de livrare. Le puteți configura aici."
           }
         },
         "ru" : {
@@ -26496,7 +28122,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dana 泵支持不同的输送速度。您可以在这里进行设置"
+            "value" : "Dana 泵支持不同的推注速率。您可以在这里进行设置"
           }
         }
       }
@@ -26554,7 +28180,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The Dana pumps support different delivery speeds. You can set it up here, but also in the settings menu"
           }
         },
@@ -26562,6 +28188,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Le pompe Dana supportano diverse velocità di erogazione. È possibile impostarla qui, ma anche nel menu delle impostazioni."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Dana-pumpene støtter forskjellige leveringshastigheter. Du kan konfigurere det her, men også i innstillingsmenyen"
           }
         },
         "nb-NO" : {
@@ -26592,6 +28224,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "The Dana pumps support different delivery speeds. You can set it up here, but also in the settings menu"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pompele Dana acceptă diferite viteze de livrare. Puteți configura acest lucru aici, dar și în meniul de setări."
           }
         },
         "ru" : {
@@ -26633,7 +28271,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Dana 泵支持不同的输送速度。您可以在这里进行设置，也可以在设置菜单中进行设置"
+            "value" : "Dana 泵支持不同的推注速率。您可以在这里进行设置，也可以在设置菜单中进行设置"
           }
         }
       }
@@ -26691,7 +28329,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The insulin delivery has been suspend. Action failed"
           }
         },
@@ -26699,6 +28337,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La somministrazione di insulina è stata sospesa. Azione fallita"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Insulintilførselen har blitt avbrutt. Handling mislyktes"
           }
         },
         "nb-NO" : {
@@ -26729,6 +28373,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "The insulin delivery has been suspend. Action failed"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Administrarea insulinei a fost suspendată. Acțiunea a eșuat."
           }
         },
         "ru" : {
@@ -26828,7 +28478,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The max bolus limit is reached. Please try a lower amount or increase the limit"
           }
         },
@@ -26836,6 +28486,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il limite massimo di bolo è stato raggiunto. Provare con una quantità inferiore o aumentare il limite"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Maksimal bolusgrense er nådd. Prøv en lavere mengde eller øk grensen."
           }
         },
         "nb-NO" : {
@@ -26866,6 +28522,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "The max bolus limit is reached. Please try a lower amount or increase the limit"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limita maximă de bolus a fost atinsă. Vă rugăm să încercați o cantitate mai mică sau să măriți limita."
           }
         },
         "ru" : {
@@ -26965,7 +28627,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The max daily insulin limit is reached. Please try a lower amount or increase the limit"
           }
         },
@@ -26973,6 +28635,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Il limite massimo di insulina giornaliero è stato raggiunto. Provare con una quantità inferiore o aumentare il limite"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Den maksimale daglige grensen for insulin er nådd. Prøv en lavere mengde eller øk grensen"
           }
         },
         "nb-NO" : {
@@ -27003,6 +28671,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "The max daily insulin limit is reached. Please try a lower amount or increase the limit"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limita maximă zilnică de insulină a fost atinsă. Vă rugăm să încercați o cantitate mai mică sau să creșteți limita."
           }
         },
         "ru" : {
@@ -27102,7 +28776,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump has detected an issue with its chaft. Please remove the reservoir, check everything and try again"
           }
         },
@@ -27110,6 +28784,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "La pompa ha rilevato un problema con il suo albero. Rimuovere il serbatoio, controllare tutto e riprovare."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpen har oppdaget et problem med skaftet. Fjern reservoaret, sjekk alt og prøv på nytt."
           }
         },
         "nb-NO" : {
@@ -27140,6 +28820,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "The pump has detected an issue with its chaft. Please remove the reservoir, check everything and try again"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pompa a detectat o problemă cu axul. Vă rugăm să scoateți rezervorul, să verificați totul și să încercați din nou."
           }
         },
         "ru" : {
@@ -27191,56 +28877,62 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
         "it" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pumpen minner deg på når mengden insulin i pumpen når dette nivået"
           }
         },
         "nb-NO" : {
@@ -27257,7 +28949,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
@@ -27273,9 +28965,15 @@
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pompa vă reamintește când cantitatea de insulină din pompă atinge acest nivel"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
@@ -27293,13 +28991,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The pump reminds you when the amount of insulin in the pump reaches this level"
           }
         },
@@ -27341,7 +29039,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Die Zeit auf Ihrer Pumpe weicht von der aktuellen Zeit ab. Möchten Sie die Zeit auf Ihrer Pumpe auf die aktuelle Zeit aktualisieren?"
+            "value" : "Die Zeit Ihrer Pumpe weicht ab. Jetzt auf aktuelle Zeit stellen?"
           }
         },
         "es" : {
@@ -27370,7 +29068,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
@@ -27413,6 +29111,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "The time on your pump is different from the current time. Do you want to update the time on your pump to the current time?"
           }
         },
@@ -27519,7 +29223,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
           }
         },
@@ -27527,6 +29231,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "L'orario impostato nel microinfusore è diverso dall'orario corrente. L'orario del microinfusore detta e controlla le impostazioni della terapia programmata e va corretto: Nella lista degli 'orari del microinfusore verificare la differenza di orario e configurare correttamente il microinfusore."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Klokken på pumpen er forskjellig fra gjeldende tid. Pumpens tid styrer dine planlagte behandlingsinnstillinger. Rull ned til Pumpetid-raden for å se tidsforskjellen og konfigurere pumpen."
           }
         },
         "nb-NO" : {
@@ -27557,6 +29267,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "The time on your pump is different from the current time. Your pump’s time controls your scheduled therapy settings. Scroll down to Pump Time row to review the time difference and configure your pump."
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ora pompei este diferită de ora curentă. Ora pompei dvs. controlează setările de terapie programate. Derulați în jos la rândul Ora pompei pentru a revizui diferența de oră și a configura pompa dvs."
           }
         },
         "ru" : {
@@ -27656,7 +29372,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "There has not been any interactions with the pump for too long. Either disable this function in the pump or interact with the pump"
           }
         },
@@ -27664,6 +29380,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Non ci sono state interazioni con la pompa per troppo tempo. Disattivare questa funzione nella pompa o interagire con la pompa."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Det har ikke vært noen interaksjon med pumpen på for lang tid. Deaktiver enten denne funksjonen i pumpen, eller samhandle med pumpen"
           }
         },
         "nb-NO" : {
@@ -27694,6 +29416,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "There has not been any interactions with the pump for too long. Either disable this function in the pump or interact with the pump"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Nu au existat interacțiuni cu pompa de prea mult timp. Fie dezactivați această funcție în pompă, fie interacționați cu pompa."
           }
         },
         "ru" : {
@@ -27787,7 +29515,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "This method of refilling is only intended for when the pump cannot provide a way to refill the reservoir or prime the cannula"
           }
         },
@@ -27795,6 +29523,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Questo metodo di riempimento è previsto solo quando la pompa non può fornire un modo per riempire il serbatoio o adescare la cannula."
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Denne påfyllingsmetoden er kun beregnet for tilfeller der pumpen ikke kan fylle opp reservoaret eller kanylen"
           }
         },
         "nb-NO" : {
@@ -27825,6 +29559,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "This method of refilling is only intended for when the pump cannot provide a way to refill the reservoir or prime the cannula"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Această metodă de reumplere este destinată numai atunci când pompa nu poate oferi o modalitate de a umple rezervorul sau de a amorsa canula"
           }
         },
         "ru" : {
@@ -27895,7 +29635,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Erkannte Zeitänderung"
+            "value" : "Zeitänderung erkannt"
           }
         },
         "es" : {
@@ -27924,7 +29664,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Time Change Detected"
           }
         },
@@ -27967,6 +29707,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "Time Change Detected"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Time Change Detected"
           }
         },
@@ -28073,7 +29819,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Toggle Bluetooth mode"
           }
         },
@@ -28081,6 +29827,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Modus Bluetooth"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slå av/på Bluetooth-modus"
           }
         },
         "nb-NO" : {
@@ -28111,6 +29863,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Toggle Bluetooth mode"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comutare mod Bluetooth"
           }
         },
         "ru" : {
@@ -28210,7 +29968,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Toggle silent tone?"
           }
         },
@@ -28218,6 +29976,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tasto silenzioso?"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Slå av/på stille tone?"
           }
         },
         "nb-NO" : {
@@ -28248,6 +30012,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Toggle silent tone?"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Comutare ton silențios?"
           }
         },
         "ru" : {
@@ -28341,7 +30111,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Tube refill amount"
           }
         },
@@ -28349,6 +30119,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Quantità di ricarica del tubo"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Mengde påfylling av rør"
           }
         },
         "nb-NO" : {
@@ -28379,6 +30155,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Tube refill amount"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Cantitate de reumplere a tubului"
           }
         },
         "ru" : {
@@ -28478,7 +30260,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Type of refill"
           }
         },
@@ -28486,6 +30268,12 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Tipo di ricarica"
+          }
+        },
+        "nb" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Type påfyll"
           }
         },
         "nb-NO" : {
@@ -28516,6 +30304,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Type of refill"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Tipul de reumplere"
           }
         },
         "ru" : {
@@ -28557,7 +30351,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "补药类型"
+            "value" : "补充方式"
           }
         }
       }
@@ -28645,7 +30439,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "U"
           }
         },
@@ -28658,6 +30452,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "U"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "U"
           }
         },
@@ -28788,7 +30588,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "U/hr"
           }
         },
@@ -28802,6 +30602,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "U/hr"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "U/oră"
           }
         },
         "ru" : {
@@ -28947,6 +30753,12 @@
             "value" : "Desconhecido"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Necunoscut"
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -29044,7 +30856,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Unknown error"
           }
         },
@@ -29088,6 +30900,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Unknown error"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Eroare necunoscută"
           }
         },
         "ru" : {
@@ -29187,7 +31005,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "User options"
           }
         },
@@ -29231,6 +31049,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "User options"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Opțiuni utilizator"
           }
         },
         "ru" : {
@@ -29330,7 +31154,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Vibration"
           }
         },
@@ -29374,6 +31198,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Vibration"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Vibrație"
           }
         },
         "ru" : {
@@ -29425,13 +31255,13 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "WARNING: Please don't use this until you've read the documentation"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "WARNING: Please don't use this until you've read the documentation"
           }
         },
@@ -29443,31 +31273,31 @@
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "WARNING: Please don't use this until you've read the documentation"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "WARNING: Please don't use this until you've read the documentation"
           }
         },
         "fr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "WARNING: Please don't use this until you've read the documentation"
           }
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "WARNING: Please don't use this until you've read the documentation"
+            "state" : "translated",
+            "value" : "אזהרה: אנא אל תשתמשו באפשרות זו עד שתקראו את התיעוד"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "WARNING: Please don't use this until you've read the documentation"
           }
         },
@@ -29497,7 +31327,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "WARNING: Please don't use this until you've read the documentation"
           }
         },
@@ -29513,9 +31343,15 @@
             "value" : "WARNING: Please don't use this until you've read the documentation"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AVERTISMENT: Vă rugăm să nu utilizați acest lucru până nu ați citit documentația."
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "WARNING: Please don't use this until you've read the documentation"
           }
         },
@@ -29533,13 +31369,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "WARNING: Please don't use this until you've read the documentation"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "WARNING: Please don't use this until you've read the documentation"
           }
         },
@@ -29604,7 +31440,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "WARNING: USE WITH CAUTION!"
           }
         },
@@ -29648,6 +31484,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "WARNING: USE WITH CAUTION!"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "AVERTISMENT: UTILIZAȚI CU ATENȚIE!"
           }
         },
         "ru" : {
@@ -29747,7 +31589,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "What is this?"
           }
         },
@@ -29791,6 +31633,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "What is this?"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Ce este aceasta?"
           }
         },
         "ru" : {
@@ -30032,7 +31880,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, 1 hour"
           }
         },
@@ -30076,6 +31924,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Yes, 1 hour"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da, 1 oră"
           }
         },
         "ru" : {
@@ -30175,7 +32029,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, 5 minutes"
           }
         },
@@ -30219,6 +32073,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Yes, 5 minutes"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da, 5 minute"
           }
         },
         "ru" : {
@@ -30318,7 +32178,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, 15 minutes"
           }
         },
@@ -30362,6 +32222,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Yes, 15 minutes"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da, 15 minute"
           }
         },
         "ru" : {
@@ -30461,7 +32327,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, 30 minutes"
           }
         },
@@ -30505,6 +32371,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Yes, 30 minutes"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da, 30 de minute"
           }
         },
         "ru" : {
@@ -30604,7 +32476,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, disable bolus syncing"
           }
         },
@@ -30648,6 +32520,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Yes, disable bolus syncing"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da, dezactivați sincronizarea bolusului"
           }
         },
         "ru" : {
@@ -30747,7 +32625,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, Disable silent tones"
           }
         },
@@ -30791,6 +32669,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Yes, Disable silent tones"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da, dezactivează tonurile silențioase"
           }
         },
         "ru" : {
@@ -30890,7 +32774,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, Enable silent tones"
           }
         },
@@ -30934,6 +32818,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Yes, Enable silent tones"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da, Activează tonurile silențioase"
           }
         },
         "ru" : {
@@ -31033,7 +32923,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, re-enable bolus syncing"
           }
         },
@@ -31077,6 +32967,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Yes, re-enable bolus syncing"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da, reactivați sincronizarea bolusurilor"
           }
         },
         "ru" : {
@@ -31176,7 +33072,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, Switch to continuous mode"
           }
         },
@@ -31220,6 +33116,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Yes, Switch to continuous mode"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da, treceți la modul continuu"
           }
         },
         "ru" : {
@@ -31319,7 +33221,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, Switch to interactive mode"
           }
         },
@@ -31363,6 +33265,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Yes, Switch to interactive mode"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Da, treceți la modul interactiv"
           }
         },
         "ru" : {
@@ -31433,7 +33341,7 @@
         "de" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Ja, Synchronisierung mit der aktuellen Zeit"
+            "value" : "Ja, mit der aktuellen Zeit synchronisieren"
           }
         },
         "es" : {
@@ -31462,7 +33370,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Yes, Sync to Current Time"
           }
         },
@@ -31505,6 +33413,12 @@
         "pt_BR" : {
           "stringUnit" : {
             "state" : "new",
+            "value" : "Yes, Sync to Current Time"
+          }
+        },
+        "pt-BR" : {
+          "stringUnit" : {
+            "state" : "translated",
             "value" : "Yes, Sync to Current Time"
           }
         },
@@ -31606,12 +33520,12 @@
         "he" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Your "
+            "value" : "שלך "
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your "
           }
         },
@@ -31655,6 +33569,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Your "
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Al tău "
           }
         },
         "ru" : {
@@ -31754,7 +33674,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your daily basal limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
@@ -31800,6 +33720,12 @@
             "value" : "Your daily basal limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limita zilnică bazală a fost atinsă. Vă rugăm să contactați distribuitorul Dana pentru a crește limita."
+          }
+        },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
@@ -31839,7 +33765,7 @@
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "您的每日基础量已达上限。请联系您的德纳经销商以增加上限"
+            "value" : "您的每日基础量已达上限。请联系您的 Dana 经销商以增加上限"
           }
         }
       }
@@ -31897,7 +33823,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your daily insulin limit has been reached. Please contact your Dana distributer to increase the limit"
           }
         },
@@ -31941,6 +33867,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Your daily insulin limit has been reached. Please contact your Dana distributer to increase the limit"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Limita zilnică de insulină a fost atinsă. Vă rugăm să contactați distribuitorul Dana pentru a crește limita."
           }
         },
         "ru" : {
@@ -31992,31 +33924,31 @@
       "localizations" : {
         "ar" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
         "da" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
         "de" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
         "es" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
         "fi" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
@@ -32028,13 +33960,13 @@
         },
         "he" : {
           "stringUnit" : {
-            "state" : "new",
-            "value" : "Your pump is disconnected longer than 5 minutes!"
+            "state" : "translated",
+            "value" : "המשאבה שלך מנותקת יותר מ-5 דקות!"
           }
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
@@ -32064,7 +33996,7 @@
         },
         "pl" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
@@ -32080,9 +34012,15 @@
             "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pompa dumneavoastră este deconectată mai mult de 5 minute!"
+          }
+        },
         "ru" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
@@ -32100,13 +34038,13 @@
         },
         "tr" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
         "uk" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your pump is disconnected longer than 5 minutes!"
           }
         },
@@ -32177,7 +34115,7 @@
         },
         "hu" : {
           "stringUnit" : {
-            "state" : "new",
+            "state" : "translated",
             "value" : "Your pump is still disconnected after the set period!"
           }
         },
@@ -32221,6 +34159,12 @@
           "stringUnit" : {
             "state" : "new",
             "value" : "Your pump is still disconnected after the set period!"
+          }
+        },
+        "ro" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Pompa dumneavoastră este încă deconectată după perioada setată!"
           }
         },
         "ru" : {

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -24,4 +24,4 @@ export_languages:
 files:
   - source: /Localization/Localizable.xcstrings
     translation: /Localization/Localizable.xcstrings
-    multilingual: true
+    multilingual: 1


### PR DESCRIPTION
## Background

The iAPS project has their own crowdin.
When the submodules were copied into the project as Dependencies, there was no link to the original repositories.
Work is on-going to transition iAPS to use forks.
However, they did not want to lose translations that already existed in iAPS.
Because DanaKit is part of LoopWorkspace, the method I used for importing the iAPS crowdin and then importing from lokalise was automatically applied to DanaKit.
This PR is for your review to decide if you want to accept it.

The MedtrumKit repository is not part of LoopWorkspace (yet), so was not included in this process.

## Method

* I locally merged the branch from this the Artificial-Pancreas fork into my local clone, branch `import_iaps_localizations`
* I added 3 languages to Xcode: ce, hu, uk
* I then did a fresh download and import from lokalise using the LoopWorkspace scripts to branch `lokalise_after_iaps_crowdin`
* In other words - if both crowdin and lokalise has a translation, the lokalise translation was used.
* A new PR was automatically generated with this process