### PR TITLE
Reorder event types for prime/replaceComponent

### DIFF
--- a/DanaKit/PumpManager/DanaKitPumpManager.swift
+++ b/DanaKit/PumpManager/DanaKitPumpManager.swift
@@ -559,7 +559,7 @@ extension DanaKitPumpManager: PumpManager {
                             dose: nil,
                             raw: item.raw,
                             title: "Prime \(value)U",
-                            type: .prime,
+                            type: .replaceComponent(componentType: .infusionSet),
                             alarmType: nil
                         ),
                         NewPumpEvent(
@@ -567,7 +567,7 @@ extension DanaKitPumpManager: PumpManager {
                             dose: nil,
                             raw: item.raw,
                             title: "Prime \(value)U",
-                            type: .replaceComponent(componentType: .infusionSet),
+                            type: .prime,
                             alarmType: nil
                         )
                     ]


### PR DESCRIPTION
This resolves an issue with [682](https://github.com/nightscout/Trio/pull/682) where Nightscout's CAGE didn't update properly because the wrong event was preferenced. This change should match MinimedKit.