### PR TITLE
feat: add simulator support for the setup and settings UI

### DIFF
--- a/DanaKit/PumpManager/DanaKitPumpManager.swift
+++ b/DanaKit/PumpManager/DanaKitPumpManager.swift
@@ -124,6 +124,30 @@ public class DanaKitPumpManager: DeviceManager {
         bluetooth.connect(peripheral, completion)
     }
 
+    #if targetEnvironment(simulator)
+    /// Simulator only: there is no CoreBluetooth here, so fabricate a connected, primed Dana-i and
+    /// report success after a short delay. This lets the setup flow finish and makes the pump
+    /// settings screens reachable without real hardware. Compiled out of device builds entirely.
+    public func connectSimulated(_ completion: @escaping () -> Void) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.5) {
+            self.state.deviceName = "DanaSim01"
+            self.state.bleIdentifier = "SIMULATOR"
+            self.state.hwModel = 0x09 // Dana-i (BLE5)
+            self.state.pumpProtocol = 0x0A
+            self.state.isConnected = true
+            self.state.reservoirLevel = 215
+            self.state.batteryRemaining = 85
+            self.state.batteryAge = Date.now
+            self.state.isPumpSuspended = false
+            self.state.bolusState = .noBolus
+            self.state.lastStatusDate = Date.now
+            self.state.pumpTime = Date.now
+            self.notifyStateDidChange()
+            completion()
+        }
+    }
+    #endif
+
     func finishV3Pairing(_ pairingKey: Data, _ randomPairingKey: Data) throws {
         try bluetooth.finishV3Pairing(pairingKey, randomPairingKey)
     }
@@ -306,6 +330,14 @@ extension DanaKitPumpManager: PumpManager {
     }
 
     public func ensureCurrentPumpData(completion: ((Date?) -> Void)?) {
+        #if targetEnvironment(simulator)
+        // No pump to poll in the simulator; report fresh data so Trio's periodic status polls and
+        // the settings screen don't hang or error against the absent device.
+        state.lastStatusDate = Date.now
+        completion?(state.lastStatusDate)
+        return
+        #endif
+
         guard Date.now.timeIntervalSince(state.lastStatusDate) > .minutes(4) else {
             log
                 .warning(

--- a/DanaKitUI/ViewModels/DanaKitScanViewModel.swift
+++ b/DanaKitUI/ViewModels/DanaKitScanViewModel.swift
@@ -33,15 +33,43 @@ class DanaKitScanViewModel: ObservableObject {
         self.pumpManager?.addScanDeviceObserver(self, queue: .main)
         self.pumpManager?.addStateObserver(self, queue: .main)
 
+        #if targetEnvironment(simulator)
+        // The simulator has no CoreBluetooth and `CBPeripheral` can't be constructed, so a real
+        // scan can never surface a device. Present a fake Dana pump instead so the setup flow can
+        // proceed to the settings screens (see `connect(_:)` and `DanaKitPumpManager.connectSimulated`).
+        isScanning = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) { [weak self] in
+            self?.scannedDevices = [ScanResultItem(name: "DanaSim01", bleIdentifier: "SIMULATOR")]
+            self?.isScanning = false
+        }
+        #else
         do {
             try self.pumpManager?.startScan()
             isScanning = true
         } catch {
             log.error("Failed to start scanning: \(error.localizedDescription)")
         }
+        #endif
     }
 
     func connect(_ item: ScanResultItem) {
+        #if targetEnvironment(simulator)
+        guard let pumpManager = pumpManager else {
+            log.error("No pump manager...")
+            return
+        }
+
+        stopScan()
+
+        isConnecting = true
+        connectingTo = item.name
+
+        // No real Bluetooth in the simulator: fabricate a connected pump, then advance the flow.
+        pumpManager.connectSimulated {
+            self.isConnecting = false
+            self.nextStep()
+        }
+        #else
         guard let pumpManager = pumpManager, let device = foundDevices[item.bleIdentifier] else {
             log.error("No view or device...")
             return
@@ -59,6 +87,7 @@ class DanaKitScanViewModel: ObservableObject {
                 self.connectComplete(result, device)
             }
         }
+        #endif
     }
 
     func connectComplete(_ result: ConnectionResult, _ peripheral: CBPeripheral) {


### PR DESCRIPTION
## Why

Unlike OmnipodKit and MinimedKit, DanaKit has no simulator path. In the iOS Simulator
there's no CoreBluetooth, a `CBPeripheral` can't be constructed, and a real scan never
surfaces a device — so pairing can never complete, the pump never onboards, and the
**post-pairing setup screens and every settings screen are unreachable**. That makes it
impossible to review or test that UI without a physical Dana pump.

## What this adds

Simulator-only behavior that lets the setup flow finish against a fake Dana-i and makes
the settings screens reachable. Everything is wrapped in `#if targetEnvironment(simulator)`,
so **device builds are completely unaffected**.

- **`DanaKitPumpManager.connectSimulated(_:)`** — fabricates a connected, primed Dana-i
  state (device name, identifiers, hw model/protocol, battery/reservoir, timestamps) after
  a short delay and reports success.
- **`DanaKitPumpManager.ensureCurrentPumpData(...)`** — short-circuits in the simulator to
  return a fresh `lastStatusDate`, so Trio's periodic status polls and the settings screen
  don't hang or error against the absent device.
- **`DanaKitScanViewModel`** — presents a fake scan result (`DanaSim01`) instead of a real
  scan, and routes `connect(_:)` through `connectSimulated` to advance the flow.

## Safety / scope

- Entirely behind `#if targetEnvironment(simulator)` — no change to device builds or
  real-hardware behavior.
- Mirrors the simulator scaffolding already in OmnipodKit (`jumpStartPod`) and MinimedKit.
- +61 lines across 2 files; no production code paths modified.

## How to test

1. Build & run Trio on an iOS Simulator.
2. Add a Dana pump and walk through setup — the scan surfaces a `DanaSim01` device.
3. Select it; after a short delay the fake pump "connects" and setup completes.
4. Open pump settings — the screens (previously unreachable in a sim) now load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)